### PR TITLE
fix sharedptr , weakptr implentation leak

### DIFF
--- a/include/hyprutils/memory/SharedPtr.hpp
+++ b/include/hyprutils/memory/SharedPtr.hpp
@@ -169,13 +169,7 @@ namespace Hyprutils {
             }
 
             ~CSharedPointer() {
-                // we do not decrement here,
-                // because we want to preserve the pointer
-                // in case this is the last owner.
-                if (impl_ && impl_->ref() == 1)
-                    destroyImpl();
-                else
-                    decrement();
+                decrement();
             }
 
             template <typename U>


### PR DESCRIPTION
if we dont decrement the sharedptr on destruction any weakptr remaining will have an impl_ with a ref of 1 and upon destruction of the weakptr it wont delete the implentation because it thinks a shared pointer still exist.

as in https://github.com/hyprwm/hyprutils/blob/0693f9398ab693d89c9a0aa3b3d062dd61b7a60e/include/hyprutils/memory/SharedPtr.hpp#L175 destruct and have impl->ref () == 1;

https://github.com/hyprwm/hyprutils/blob/0693f9398ab693d89c9a0aa3b3d062dd61b7a60e/include/hyprutils/memory/WeakPtr.hpp#L171 weakptr will not delete it because it still has a ref above 0. but the sharedptr is actually dead.

destroyImpl() also already checks for weakptr ref before deleting impl so the comment section in the old destruction logic shouldnt be true.

leak can be seen in the hyprutils_memory test or hyprland itself
```
┤tom-legion->tom main ~/dev/hyprutils/build/Desktop-Debug
└➤ valgrind ./hyprutils_memory --leak-check=full
==43588== Memcheck, a memory error detector
==43588== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al.
==43588== Using Valgrind-3.23.1.GIT and LibVEX; rerun with -h for copyright info
==43588== Command: ./hyprutils_memory --leak-check=full
==43588== 
Passed *intPtr. Got 10
Passed intPtr.strongRef(). Got 1
Passed *intPtr. Got 10
Passed intPtr.strongRef(). Got 1
Passed *weak.get(). Got 10
Passed weak.expired(). Got 0
Passed weak.expired(). Got 1
==43588== 
==43588== HEAP SUMMARY:
==43588==     in use at exit: 32 bytes in 1 blocks
==43588==   total heap usage: 4 allocs, 3 frees, 74,788 bytes allocated
==43588== 
==43588== LEAK SUMMARY:
==43588==    definitely lost: 32 bytes in 1 blocks
==43588==    indirectly lost: 0 bytes in 0 blocks
==43588==      possibly lost: 0 bytes in 0 blocks
==43588==    still reachable: 0 bytes in 0 blocks
==43588==         suppressed: 0 bytes in 0 blocks
==43588== Rerun with --leak-check=full to see details of leaked memory
==43588== 
==43588== For lists of detected and suppressed errors, rerun with: -s
==43588== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```