### PR TITLE
avoid undefined behaviour from downcasting ptr implentation

### DIFF
--- a/include/hyprutils/memory/SharedPtr.hpp
+++ b/include/hyprutils/memory/SharedPtr.hpp
@@ -20,7 +20,7 @@ namespace Hyprutils {
         namespace CSharedPointer_ {
             class impl_base {
               public:
-                virtual ~impl_base(){};
+                virtual ~impl_base() {};
 
                 virtual void         inc() noexcept         = 0;
                 virtual void         dec() noexcept         = 0;
@@ -31,6 +31,7 @@ namespace Hyprutils {
                 virtual void         destroy() noexcept     = 0;
                 virtual bool         destroying() noexcept  = 0;
                 virtual bool         dataNonNull() noexcept = 0;
+                virtual void*        getData() noexcept     = 0;
             };
 
             template <typename T>
@@ -107,6 +108,10 @@ namespace Hyprutils {
                 }
 
                 virtual bool dataNonNull() noexcept {
+                    return _data != nullptr;
+                }
+
+                virtual void* getData() noexcept {
                     return _data;
                 }
 
@@ -234,7 +239,7 @@ namespace Hyprutils {
             }
 
             T* get() const {
-                return (T*)(impl_ ? static_cast<CSharedPointer_::impl<T>*>(impl_)->_data : nullptr);
+                return impl_ ? static_cast<T*>(impl_->getData()) : nullptr;
             }
 
             unsigned int strongRef() const {

--- a/include/hyprutils/memory/SharedPtr.hpp
+++ b/include/hyprutils/memory/SharedPtr.hpp
@@ -218,11 +218,11 @@ namespace Hyprutils {
             }
 
             bool operator()(const CSharedPointer& lhs, const CSharedPointer& rhs) const {
-                return (uintptr_t)lhs.impl_ < (uintptr_t)rhs.impl_;
+                return reinterpret_cast<uintptr_t>(lhs.impl_) < reinterpret_cast<uintptr_t>(rhs.impl_);
             }
 
             bool operator<(const CSharedPointer& rhs) const {
-                return (uintptr_t)impl_ < (uintptr_t)rhs.impl_;
+                return reinterpret_cast<uintptr_t>(impl_) < reinterpret_cast<uintptr_t>(rhs.impl_);
             }
 
             T* operator->() const {

--- a/include/hyprutils/memory/WeakPtr.hpp
+++ b/include/hyprutils/memory/WeakPtr.hpp
@@ -147,7 +147,7 @@ namespace Hyprutils {
             }
 
             T* get() const {
-                return (T*)(impl_ ? static_cast<CSharedPointer_::impl<T>*>(impl_)->_data : nullptr);
+                return impl_ ? static_cast<T*>(impl_->getData()) : nullptr;
             }
 
             T* operator->() const {

--- a/include/hyprutils/memory/WeakPtr.hpp
+++ b/include/hyprutils/memory/WeakPtr.hpp
@@ -80,7 +80,7 @@ namespace Hyprutils {
             /* create a weak ptr from a shared ptr with assignment */
             template <typename U>
             validHierarchy<const CWeakPointer<U>&> operator=(const CSharedPointer<U>& rhs) {
-                if ((uintptr_t)impl_ == (uintptr_t)rhs.impl_)
+                if (reinterpret_cast<uintptr_t>(impl_) == reinterpret_cast<uintptr_t>(rhs.impl_))
                     return *this;
 
                 decrementWeak();
@@ -139,11 +139,11 @@ namespace Hyprutils {
             }
 
             bool operator()(const CWeakPointer& lhs, const CWeakPointer& rhs) const {
-                return (uintptr_t)lhs.impl_ < (uintptr_t)rhs.impl_;
+                return reinterpret_cast<uintptr_t>(lhs.impl_) < reinterpret_cast<uintptr_t>(rhs.impl_);
             }
 
             bool operator<(const CWeakPointer& rhs) const {
-                return (uintptr_t)impl_ < (uintptr_t)rhs.impl_;
+                return reinterpret_cast<uintptr_t>(impl_) < reinterpret_cast<uintptr_t>(rhs.impl_);
             }
 
             T* get() const {


### PR DESCRIPTION
errors can be seen with UBSAN in hyprland like 

```
/usr/include/hyprutils/memory/SharedPtr.hpp:237:84: runtime error: member access within address 0x5030000e0710 which does not point to an object of type 'CSharedPointer_::impl<IKeyboard>'
0x5030000e0710: note: object is of type 'Hyprutils::Memory::CSharedPointer_::impl<CKeyboard>'
 00 00 00 00  10 c9 36 5e 55 55 00 00  02 00 00 00 02 00 00 00  80 fb 04 00 90 51 00 00  00 be be be
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'Hyprutils::Memory::CSharedPointer_::impl<CKeyboard>'
    #0 0x555559ff09f5 in Hyprutils::Memory::CSharedPointer<IKeyboard>::get() const /usr/include/hyprutils/memory/SharedPtr.hpp:237:84
    #1 0x555559fef658 in Hyprutils::Memory::CSharedPointer<IKeyboard>::operator->() const /usr/include/hyprutils/memory/SharedPtr.hpp:224:24
   
```

```
/usr/include/hyprutils/memory/WeakPtr.hpp:150:37: runtime error: downcast of address 0x5030000e0710 which does not point to an object of type 'CSharedPointer_::impl<IKeyboard>'
0x5030000e0710: note: object is of type 'Hyprutils::Memory::CSharedPointer_::impl<CKeyboard>'
 00 00 00 00  10 15 36 5e 55 55 00 00  03 00 00 00 03 00 00 00  80 fb 04 00 90 51 00 00  00 be be be
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'Hyprutils::Memory::CSharedPointer_::impl<CKeyboard>'
    #0 0x55555a58ae45 in Hyprutils::Memory::CWeakPointer<IKeyboard>::get() const /usr/include/hyprutils/memory/WeakPtr.hpp:150:37
    #1 0x55555a5842a8 in Hyprutils::Memory::CWeakPointer<IKeyboard>::operator->() const /usr/include/hyprutils/memory/WeakPtr.hpp:154:24
```

and the reason is because CKeyboard is a derived class from the base IKeyboard so the underlaying ptr can be casted but the implentation stored in the ptrs is not related. so add a getter and only cast the underlaying ptr.

also change C style casts in favour of reinterpret_cast.
