### PR TITLE
string: respect removeEmpty when VarList input is empty

### DIFF
--- a/include/hyprutils/string/VarList.hpp
+++ b/include/hyprutils/string/VarList.hpp
@@ -12,7 +12,7 @@ namespace Hyprutils {
                 @param delim if delimiter is 's', use std::isspace
                 @param removeEmpty remove empty args from argv
             */
-            CVarList(const std::string& in, const size_t maxSize = 0, const char delim = ',', const bool removeEmpty = false);
+            CVarList(const std::string& in, const size_t lastArgNo = 0, const char delim = ',', const bool removeEmpty = false);
 
             ~CVarList() = default;
 

--- a/src/string/VarList.cpp
+++ b/src/string/VarList.cpp
@@ -6,7 +6,7 @@
 using namespace Hyprutils::String;
 
 Hyprutils::String::CVarList::CVarList(const std::string& in, const size_t lastArgNo, const char delim, const bool removeEmpty) {
-    if (in.empty())
+    if (!removeEmpty && in.empty())
         m_vArgs.emplace_back("");
 
     std::string args{in};


### PR DESCRIPTION
Makes `VarList` respect `removeEmpty` when `in` is empty.

I think it does not cause any negative side effects, because `operator[]` will return an empty string, when `idx >= m_vArgs.size()` anyways.

Or is it intended behaviour that `CVarList` always contains at least one arguement?

Motivated by https://github.com/hyprwm/hyprlock/pull/396