### PR TITLE
path: add findConfig and dir utils

### DIFF
--- a/include/hyprutils/path/Path.hpp
+++ b/include/hyprutils/path/Path.hpp
@@ -1,0 +1,39 @@
+#pragma once
+#include "../string/VarList.hpp"
+#include <string>
+#include <optional>
+
+namespace Hyprutils {
+    namespace Path {
+        /** Check whether a config in the form basePath/hypr/programName.conf exists.
+            @param basePath the path where the config will be searched
+            @param programName name of the program (and config file) to search for
+        */
+        bool checkConfigExists(const std::string basePath, const std::string programName);
+
+        /** Constructs a full config path given the basePath and programName.
+            @param basePath the path where the config hypr/programName.conf is located
+            @param programName name of the program (and config file)
+        */
+        std::string fullConfigPath(const std::string basePath, const std::string programName);
+
+        /** Retrieves the absolute path of the $HOME env variable.
+        */
+        std::optional<std::string> getHome();
+
+        /** Retrieves a CVarList of paths from the $XDG_CONFIG_DIRS env variable.
+        */
+        std::optional<String::CVarList> getXdgConfigDirs();
+
+        /** Retrieves the absolute path of the $XDG_CONFIG_HOME env variable.
+        */
+        std::optional<std::string> getXdgConfigHome();
+
+        /** Searches for a config according to the XDG Base Directory specification.
+            Returns either the full path to a config if found, or
+            $XDG_CONFIG_HOME/$HOME if no config could be found.
+            @param programName name of the program (and config file)
+        */
+        std::optional<std::string> findConfig(const std::string programName);
+    }
+}

--- a/include/hyprutils/path/Path.hpp
+++ b/include/hyprutils/path/Path.hpp
@@ -2,6 +2,7 @@
 #include "../string/VarList.hpp"
 #include <string>
 #include <optional>
+#include <utility>
 
 namespace Hyprutils {
     namespace Path {
@@ -30,10 +31,12 @@ namespace Hyprutils {
         std::optional<std::string> getXdgConfigHome();
 
         /** Searches for a config according to the XDG Base Directory specification.
-            Returns either the full path to a config if found, or
-            $XDG_CONFIG_HOME/$HOME if no config could be found.
+            Returns a pair of the full path to a config and the base path.
+            Returns std::nullopt in case of a non-existent value.
             @param programName name of the program (and config file)
         */
-        std::optional<std::string> findConfig(const std::string programName);
+
+        using T = std::optional<std::string>;
+        std::pair<T, T> findConfig(const std::string programName);
     }
 }

--- a/src/path/Path.cpp
+++ b/src/path/Path.cpp
@@ -42,41 +42,31 @@ namespace Hyprutils::Path {
         return xdgConfigHome;
     }
 
-    std::optional<std::string> findConfig(std::string programName) {
-        bool              xdgConfigHomeExists = false;
-        static const auto xdgConfigHome       = getXdgConfigHome();
+    using T = std::optional<std::string>;
+    std::pair<T, T> findConfig(std::string programName) {
+        static const auto xdgConfigHome = getXdgConfigHome();
         if (xdgConfigHome.has_value()) {
             if (checkConfigExists(xdgConfigHome.value(), programName))
-                return fullConfigPath(xdgConfigHome.value(), programName);
-            else
-                xdgConfigHomeExists = true;
+                return std::make_pair(fullConfigPath(xdgConfigHome.value(), programName), xdgConfigHome);
         }
 
-        bool              homeExists = false;
-        static const auto home       = getHome();
+        static const auto home = getHome();
         if (home.has_value()) {
             if (checkConfigExists(home.value(), programName))
-                return fullConfigPath(home.value(), programName);
-            else
-                homeExists = true;
+                return std::make_pair(fullConfigPath(home.value(), programName), home);
         }
 
         static const auto xdgConfigDirs = getXdgConfigDirs();
         if (xdgConfigDirs.has_value()) {
             for (auto dir : xdgConfigDirs.value()) {
                 if (checkConfigExists(dir, programName))
-                    return fullConfigPath(dir, programName);
+                    return std::make_pair(fullConfigPath(dir, programName), std::nullopt);
             }
         }
 
         if (checkConfigExists("/etc/xdg", programName))
-            return fullConfigPath("/etc/xdg", programName);
+            return std::make_pair(fullConfigPath("/etc/xdg", programName), std::nullopt);
 
-        if (xdgConfigHomeExists)
-            return xdgConfigHome;
-        else if (homeExists)
-            return home;
-        else
-            return std::nullopt;
+        return std::make_pair(std::nullopt, std::nullopt);
     }
 }

--- a/src/path/Path.cpp
+++ b/src/path/Path.cpp
@@ -44,20 +44,20 @@ namespace Hyprutils::Path {
 
     using T = std::optional<std::string>;
     std::pair<T, T> findConfig(std::string programName) {
-        static const auto xdgConfigHome = getXdgConfigHome();
+        bool              xdgConfigHomeExists = false;
+        static const auto xdgConfigHome       = getXdgConfigHome();
         if (xdgConfigHome.has_value()) {
+            xdgConfigHomeExists = true;
             if (checkConfigExists(xdgConfigHome.value(), programName))
                 return std::make_pair(fullConfigPath(xdgConfigHome.value(), programName), xdgConfigHome);
-            else
-                return std::make_pair(std::nullopt, xdgConfigHome);
         }
 
-        static const auto home = getHome();
+        bool              homeExists = false;
+        static const auto home       = getHome();
         if (home.has_value()) {
+            homeExists = true;
             if (checkConfigExists(home.value(), programName))
                 return std::make_pair(fullConfigPath(home.value(), programName), home);
-            else
-                return std::make_pair(std::nullopt, home);
         }
 
         static const auto xdgConfigDirs = getXdgConfigDirs();
@@ -70,6 +70,11 @@ namespace Hyprutils::Path {
 
         if (checkConfigExists("/etc/xdg", programName))
             return std::make_pair(fullConfigPath("/etc/xdg", programName), std::nullopt);
+
+        if (xdgConfigHomeExists)
+            return std::make_pair(std::nullopt, xdgConfigHome);
+        else if (homeExists)
+            return std::make_pair(std::nullopt, home);
 
         return std::make_pair(std::nullopt, std::nullopt);
     }

--- a/src/path/Path.cpp
+++ b/src/path/Path.cpp
@@ -48,12 +48,16 @@ namespace Hyprutils::Path {
         if (xdgConfigHome.has_value()) {
             if (checkConfigExists(xdgConfigHome.value(), programName))
                 return std::make_pair(fullConfigPath(xdgConfigHome.value(), programName), xdgConfigHome);
+            else
+                return std::make_pair(std::nullopt, xdgConfigHome);
         }
 
         static const auto home = getHome();
         if (home.has_value()) {
             if (checkConfigExists(home.value(), programName))
                 return std::make_pair(fullConfigPath(home.value(), programName), home);
+            else
+                return std::make_pair(std::nullopt, home);
         }
 
         static const auto xdgConfigDirs = getXdgConfigDirs();

--- a/src/path/Path.cpp
+++ b/src/path/Path.cpp
@@ -1,0 +1,82 @@
+#include <hyprutils/path/Path.hpp>
+#include <hyprutils/string/VarList.hpp>
+#include <filesystem>
+
+using namespace Hyprutils;
+
+namespace Hyprutils::Path {
+    std::string fullConfigPath(std::string basePath, std::string programName) {
+        return basePath + "/hypr/" + programName + ".conf";
+    }
+
+    bool checkConfigExists(std::string basePath, std::string programName) {
+        return std::filesystem::exists(fullConfigPath(basePath, programName));
+    }
+
+    std::optional<std::string> getHome() {
+        static const auto homeDir = getenv("HOME");
+
+        if (!homeDir || !std::filesystem::path(homeDir).is_absolute())
+            return std::nullopt;
+
+        return std::string(homeDir).append("/.config");
+    }
+
+    std::optional<String::CVarList> getXdgConfigDirs() {
+        static const auto xdgConfigDirs = getenv("XDG_CONFIG_DIRS");
+
+        if (!xdgConfigDirs)
+            return std::nullopt;
+
+        static const auto xdgConfigDirsList = String::CVarList(xdgConfigDirs, 0, ':');
+
+        return xdgConfigDirsList;
+    }
+
+    std::optional<std::string> getXdgConfigHome() {
+        static const auto xdgConfigHome = getenv("XDG_CONFIG_HOME");
+
+        if (!xdgConfigHome || !std::filesystem::path(xdgConfigHome).is_absolute())
+            return std::nullopt;
+
+        return xdgConfigHome;
+    }
+
+    std::optional<std::string> findConfig(std::string programName) {
+        bool              xdgConfigHomeExists = false;
+        static const auto xdgConfigHome       = getXdgConfigHome();
+        if (xdgConfigHome.has_value()) {
+            if (checkConfigExists(xdgConfigHome.value(), programName))
+                return fullConfigPath(xdgConfigHome.value(), programName);
+            else
+                xdgConfigHomeExists = true;
+        }
+
+        bool              homeExists = false;
+        static const auto home       = getHome();
+        if (home.has_value()) {
+            if (checkConfigExists(home.value(), programName))
+                return fullConfigPath(home.value(), programName);
+            else
+                homeExists = true;
+        }
+
+        static const auto xdgConfigDirs = getXdgConfigDirs();
+        if (xdgConfigDirs.has_value()) {
+            for (auto dir : xdgConfigDirs.value()) {
+                if (checkConfigExists(dir, programName))
+                    return fullConfigPath(dir, programName);
+            }
+        }
+
+        if (checkConfigExists("/etc/xdg", programName))
+            return fullConfigPath("/etc/xdg", programName);
+
+        if (xdgConfigHomeExists)
+            return xdgConfigHome;
+        else if (homeExists)
+            return home;
+        else
+            return std::nullopt;
+    }
+}


### PR DESCRIPTION
Adds a common function `findConfig` to be used by hypr* programs, allowing them to easily find configs according to the [XDG Base Directory specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html). Furthermore, if any of the XDG user variables exists but a config is not found, the variable will be returned as-is, and programs will be responsible for auto-generating configs in the provided location or handling the path in another way.
