### PR TITLE
fix spam complain abt animation

### DIFF
--- a/include/hyprutils/animation/AnimationManager.hpp
+++ b/include/hyprutils/animation/AnimationManager.hpp
@@ -14,6 +14,7 @@ namespace Hyprutils {
         class CAnimationManager {
           public:
             CAnimationManager();
+			virtual ~CAnimationManager() = default;
 
             void                                                                         tickDone();
             bool                                                                         shouldTickForNext();


### PR DESCRIPTION
Added a virtual destructor to CAnimationManager to suppress -Wnon-virtual-dtor warnings and ensure proper cleanup of derived classes.
