### PR TITLE
add virtual destructor to CAnimationManager

### DIFF
--- a/include/hyprutils/animation/AnimationManager.hpp
+++ b/include/hyprutils/animation/AnimationManager.hpp
@@ -14,6 +14,7 @@ namespace Hyprutils {
         class CAnimationManager {
           public:
             CAnimationManager();
+            virtual ~CAnimationManager() = default;
 
             void                                                                         tickDone();
             bool                                                                         shouldTickForNext();


### PR DESCRIPTION
fixes compile warning in Hyprland complaining about non-virtual dtor with virtual functions in CAnimationManager class