### PR TITLE
animations: fix adding/removing vars during ::tick

### DIFF
--- a/include/hyprutils/animation/AnimatedVariable.hpp
+++ b/include/hyprutils/animation/AnimatedVariable.hpp
@@ -148,9 +148,9 @@ namespace Hyprutils {
 
                 m_Value = m_Goal;
 
-                m_bIsBeingAnimated = false;
-
                 onUpdate();
+
+                m_bIsBeingAnimated = false;
 
                 if (endCallback)
                     onAnimationEnd();

--- a/tests/animation.cpp
+++ b/tests/animation.cpp
@@ -43,8 +43,8 @@ CAnimationConfigTree animationTree;
 class CMyAnimationManager : public CAnimationManager {
   public:
     void tick() {
-        for (auto const& av : m_vActiveAnimatedVariables) {
-            const auto PAV = av.lock();
+        for (size_t i = 0; i < m_vActiveAnimatedVariables.size(); i++) {
+            const auto PAV = m_vActiveAnimatedVariables[i].lock();
             if (!PAV || !PAV->ok())
                 continue;
 
@@ -80,7 +80,7 @@ class CMyAnimationManager : public CAnimationManager {
                 } break;
             }
 
-            av->onUpdate();
+            PAV->onUpdate();
         }
 
         tickDone();


### PR DESCRIPTION
Basically only changes the test itself.
Also contains a fix for the update callback not being called when warping.

Does not break ABI I think?