### PR TITLE
Add virtual destructor to CAnimationManager

### DIFF
--- a/include/hyprutils/animation/AnimationManager.hpp
+++ b/include/hyprutils/animation/AnimationManager.hpp
@@ -29,7 +29,9 @@ namespace Hyprutils {
 
             const std::unordered_map<std::string, Memory::CSharedPointer<CBezierCurve>>& getAllBeziers();
 
-            std::vector<Memory::CWeakPointer<CBaseAnimatedVariable>>                     m_vActiveAnimatedVariables;
+            virtual                                                                      ~CAnimationManager() {};
+
+            std::vector<Memory::CWeakPointer<CBaseAnimatedVariable>> m_vActiveAnimatedVariables;
 
           private:
             std::unordered_map<std::string, Memory::CSharedPointer<CBezierCurve>> m_mBezierCurves;


### PR DESCRIPTION
This mollifies C++ compilers so that they don't make warnings like "has virtual functions and accessible non-virtual destructor", and also fixes the problems that are the reasons for such warnings.

Addresses issue https://github.com/hyprwm/hyprutils/issues/36.