### PR TITLE
animation: let callbacks have SP's to the self variable and dispatch them internally

### DIFF
--- a/include/hyprutils/animation/AnimatedVariable.hpp
+++ b/include/hyprutils/animation/AnimatedVariable.hpp
@@ -14,7 +14,7 @@ namespace Hyprutils {
         /* A base class for animated variables. */
         class CBaseAnimatedVariable {
           public:
-            using CallbackFun = std::function<void(Memory::CWeakPointer<CBaseAnimatedVariable> thisptr)>;
+            using CallbackFun = std::function<void(Memory::CSharedPointer<CBaseAnimatedVariable> thisptr)>;
 
             CBaseAnimatedVariable() {
                 ; // m_bDummy = true;

--- a/include/hyprutils/animation/AnimationManager.hpp
+++ b/include/hyprutils/animation/AnimationManager.hpp
@@ -14,6 +14,7 @@ namespace Hyprutils {
         class CAnimationManager {
           public:
             CAnimationManager();
+            virtual ~CAnimationManager() = default;
 
             void                                                                         tickDone();
             bool                                                                         shouldTickForNext();


### PR DESCRIPTION
I lost the confidence that just looping over indices makes it safe. Haven't seen a crash per se, but after rethinking, I think this is better to be safe.

This breaks the ABI (callback WP->SP), so I also included the virtual dtor here in case we merge this.
Also `onUpdate` need to be removed from the `tick` method in hyprland/lock, cause that is now handled in `tickDone`