### PR TITLE
animation: fix crashes and cleanup of active vars

### DIFF
--- a/include/hyprutils/animation/AnimatedVariable.hpp
+++ b/include/hyprutils/animation/AnimatedVariable.hpp
@@ -96,7 +96,8 @@ namespace Hyprutils {
 
             struct {
                 Memory::CWeakPointer<Signal::CSignal> connect;
-                Memory::CWeakPointer<Signal::CSignal> disconnect;
+                Memory::CWeakPointer<Signal::CSignal> forceDisconnect;
+                Memory::CWeakPointer<Signal::CSignal> lazyDisconnect;
             } m_sEvents;
 
           private:

--- a/include/hyprutils/animation/AnimatedVariable.hpp
+++ b/include/hyprutils/animation/AnimatedVariable.hpp
@@ -14,8 +14,7 @@ namespace Hyprutils {
 
         struct SAnimVarEvents {
             Signal::CSignal connect;
-            Signal::CSignal forceDisconnect;
-            Signal::CSignal lazyDisconnect;
+            Signal::CSignal disconnect;
         };
 
         /* A base class for animated variables. */
@@ -164,10 +163,8 @@ namespace Hyprutils {
                 if (endCallback)
                     onAnimationEnd();
 
-                if (forceDisconnect) {
-                    if (const auto PEVENTS = m_events.lock())
-                        PEVENTS->forceDisconnect.emit(static_cast<void*>(this));
-                }
+                if (forceDisconnect)
+                    disconnectFromActive();
             }
 
             const VarType& value() const {

--- a/include/hyprutils/animation/AnimatedVariable.hpp
+++ b/include/hyprutils/animation/AnimatedVariable.hpp
@@ -12,6 +12,12 @@ namespace Hyprutils {
     namespace Animation {
         class CAnimationManager;
 
+        struct SAnimVarEvents {
+            Signal::CSignal connect;
+            Signal::CSignal forceDisconnect;
+            Signal::CSignal lazyDisconnect;
+        };
+
         /* A base class for animated variables. */
         class CBaseAnimatedVariable {
           public:
@@ -94,12 +100,6 @@ namespace Hyprutils {
 
             Memory::CWeakPointer<CBaseAnimatedVariable> m_pSelf;
 
-            struct {
-                Memory::CWeakPointer<Signal::CSignal> connect;
-                Memory::CWeakPointer<Signal::CSignal> forceDisconnect;
-                Memory::CWeakPointer<Signal::CSignal> lazyDisconnect;
-            } m_sEvents;
-
           private:
             Memory::CWeakPointer<SAnimationPropertyConfig> m_pConfig;
 
@@ -109,14 +109,16 @@ namespace Hyprutils {
 
             // TODO: remove this pointer. We still need it for getBezier in getCurveValue.
             // getCurveValue is only used once in Hyprland. So either remove it or just pass pAnimationManager as a param.
-            CAnimationManager* m_pAnimationManager = nullptr;
+            CAnimationManager*                   m_pAnimationManager = nullptr;
 
-            bool               m_bRemoveEndAfterRan   = true;
-            bool               m_bRemoveBeginAfterRan = true;
+            Memory::CWeakPointer<SAnimVarEvents> m_events;
 
-            CallbackFun        m_fEndCallback;
-            CallbackFun        m_fBeginCallback;
-            CallbackFun        m_fUpdateCallback;
+            bool                                 m_bRemoveEndAfterRan   = true;
+            bool                                 m_bRemoveBeginAfterRan = true;
+
+            CallbackFun                          m_fEndCallback;
+            CallbackFun                          m_fBeginCallback;
+            CallbackFun                          m_fUpdateCallback;
         };
 
         /* This concept represents the minimum requirement for a type to be used with CGenericAnimatedVariable */

--- a/include/hyprutils/animation/AnimatedVariable.hpp
+++ b/include/hyprutils/animation/AnimatedVariable.hpp
@@ -2,7 +2,8 @@
 
 #include "AnimationConfig.hpp"
 #include "../memory/WeakPtr.hpp"
-#include "hyprutils/memory/SharedPtr.hpp"
+#include "../memory/SharedPtr.hpp"
+#include "../signal/Signal.hpp"
 
 #include <functional>
 #include <chrono>
@@ -93,6 +94,11 @@ namespace Hyprutils {
 
             Memory::CWeakPointer<CBaseAnimatedVariable> m_pSelf;
 
+            struct {
+                Memory::CWeakPointer<Signal::CSignal> connect;
+                Memory::CWeakPointer<Signal::CSignal> disconnect;
+            } m_sEvents;
+
           private:
             Memory::CWeakPointer<SAnimationPropertyConfig> m_pConfig;
 
@@ -100,13 +106,16 @@ namespace Hyprutils {
 
             bool                                           m_bDummy = true;
 
-            CAnimationManager*                             m_pAnimationManager    = nullptr;
-            bool                                           m_bRemoveEndAfterRan   = true;
-            bool                                           m_bRemoveBeginAfterRan = true;
+            // TODO: remove this pointer. We still need it for getBezier in getCurveValue.
+            // getCurveValue is only used once in Hyprland. So either remove it or just pass pAnimationManager as a param.
+            CAnimationManager* m_pAnimationManager = nullptr;
 
-            CallbackFun                                    m_fEndCallback;
-            CallbackFun                                    m_fBeginCallback;
-            CallbackFun                                    m_fUpdateCallback;
+            bool               m_bRemoveEndAfterRan   = true;
+            bool               m_bRemoveBeginAfterRan = true;
+
+            CallbackFun        m_fEndCallback;
+            CallbackFun        m_fBeginCallback;
+            CallbackFun        m_fUpdateCallback;
         };
 
         /* This concept represents the minimum requirement for a type to be used with CGenericAnimatedVariable */

--- a/include/hyprutils/animation/AnimationManager.hpp
+++ b/include/hyprutils/animation/AnimationManager.hpp
@@ -4,6 +4,7 @@
 #include "./AnimatedVariable.hpp"
 #include "../math/Vector2D.hpp"
 #include "../memory/WeakPtr.hpp"
+#include "../signal/Signal.hpp"
 
 #include <unordered_map>
 #include <vector>
@@ -22,6 +23,9 @@ namespace Hyprutils {
             virtual void                                                                 scheduleTick() = 0;
             virtual void                                                                 onTicked()     = 0;
 
+            void                                                                         connectVarListener(std::any data);
+            void                                                                         disconnectVarListener(std::any data);
+
             void                                                                         addBezierWithName(std::string, const Math::Vector2D&, const Math::Vector2D&);
             void                                                                         removeAllBeziers();
 
@@ -36,6 +40,19 @@ namespace Hyprutils {
             std::unordered_map<std::string, Memory::CSharedPointer<CBezierCurve>> m_mBezierCurves;
 
             bool                                                                  m_bTickScheduled = false;
+
+            struct {
+                Signal::CHyprSignalListener connect;
+                Signal::CHyprSignalListener disconnect;
+            } m_sListeners;
+
+            struct {
+                // Those events are shared between animated vars
+                Memory::CSharedPointer<Signal::CSignal> connect;
+                Memory::CSharedPointer<Signal::CSignal> disconnect;
+            } m_sEvents;
+
+            friend class CBaseAnimatedVariable;
         };
     }
 }

--- a/include/hyprutils/animation/AnimationManager.hpp
+++ b/include/hyprutils/animation/AnimationManager.hpp
@@ -33,25 +33,23 @@ namespace Hyprutils {
 
             const std::unordered_map<std::string, Memory::CSharedPointer<CBezierCurve>>& getAllBeziers();
 
+            Memory::CSharedPointer<SAnimVarEvents>                                       getEvents() const;
+
             std::vector<Memory::CWeakPointer<CBaseAnimatedVariable>>                     m_vActiveAnimatedVariables;
+            Memory::CSharedPointer<SAnimVarEvents>                                       m_events;
 
           private:
             std::unordered_map<std::string, Memory::CSharedPointer<CBezierCurve>> m_mBezierCurves;
 
-            bool                                                                  m_bTickScheduled     = false;
-            uint32_t                                                              m_pendingDisconnects = 0;
+            bool                                                                  m_bTickScheduled = false;
 
             void                                                                  connectListener(std::any data);
-            void                                                                  lazyDisconnectListener(std::any data);
             void                                                                  forceDisconnectListener(std::any data);
 
             struct {
                 Signal::CHyprSignalListener connect;
                 Signal::CHyprSignalListener forceDisconnect;
-                Signal::CHyprSignalListener lazyDisconnect;
             } m_sListeners;
-
-            Memory::CSharedPointer<SAnimVarEvents> m_events;
 
             friend class CBaseAnimatedVariable;
         };

--- a/include/hyprutils/animation/AnimationManager.hpp
+++ b/include/hyprutils/animation/AnimationManager.hpp
@@ -6,6 +6,7 @@
 #include "../memory/WeakPtr.hpp"
 #include "../signal/Signal.hpp"
 
+#include <cstdint>
 #include <unordered_map>
 #include <vector>
 
@@ -18,13 +19,15 @@ namespace Hyprutils {
             virtual ~CAnimationManager() = default;
 
             void                                                                         tickDone();
+            void                                                                         rotateActive();
             bool                                                                         shouldTickForNext();
 
             virtual void                                                                 scheduleTick() = 0;
             virtual void                                                                 onTicked()     = 0;
 
-            void                                                                         connectVarListener(std::any data);
-            void                                                                         disconnectVarListener(std::any data);
+            void                                                                         connectListener(std::any data);
+            void                                                                         lazyDisconnectListener(std::any data);
+            void                                                                         forceDisconnectListener(std::any data);
 
             void                                                                         addBezierWithName(std::string, const Math::Vector2D&, const Math::Vector2D&);
             void                                                                         removeAllBeziers();
@@ -39,17 +42,20 @@ namespace Hyprutils {
           private:
             std::unordered_map<std::string, Memory::CSharedPointer<CBezierCurve>> m_mBezierCurves;
 
-            bool                                                                  m_bTickScheduled = false;
+            bool                                                                  m_bTickScheduled     = false;
+            uint32_t                                                              m_pendingDisconnects = 0;
 
             struct {
                 Signal::CHyprSignalListener connect;
-                Signal::CHyprSignalListener disconnect;
+                Signal::CHyprSignalListener forceDisconnect;
+                Signal::CHyprSignalListener lazyDisconnect;
             } m_sListeners;
 
             struct {
                 // Those events are shared between animated vars
                 Memory::CSharedPointer<Signal::CSignal> connect;
-                Memory::CSharedPointer<Signal::CSignal> disconnect;
+                Memory::CSharedPointer<Signal::CSignal> forceDisconnect;
+                Memory::CSharedPointer<Signal::CSignal> lazyDisconnect;
             } m_sEvents;
 
             friend class CBaseAnimatedVariable;

--- a/include/hyprutils/animation/AnimationManager.hpp
+++ b/include/hyprutils/animation/AnimationManager.hpp
@@ -25,10 +25,6 @@ namespace Hyprutils {
             virtual void                                                                 scheduleTick() = 0;
             virtual void                                                                 onTicked()     = 0;
 
-            void                                                                         connectListener(std::any data);
-            void                                                                         lazyDisconnectListener(std::any data);
-            void                                                                         forceDisconnectListener(std::any data);
-
             void                                                                         addBezierWithName(std::string, const Math::Vector2D&, const Math::Vector2D&);
             void                                                                         removeAllBeziers();
 
@@ -45,18 +41,17 @@ namespace Hyprutils {
             bool                                                                  m_bTickScheduled     = false;
             uint32_t                                                              m_pendingDisconnects = 0;
 
+            void                                                                  connectListener(std::any data);
+            void                                                                  lazyDisconnectListener(std::any data);
+            void                                                                  forceDisconnectListener(std::any data);
+
             struct {
                 Signal::CHyprSignalListener connect;
                 Signal::CHyprSignalListener forceDisconnect;
                 Signal::CHyprSignalListener lazyDisconnect;
             } m_sListeners;
 
-            struct {
-                // Those events are shared between animated vars
-                Memory::CSharedPointer<Signal::CSignal> connect;
-                Memory::CSharedPointer<Signal::CSignal> forceDisconnect;
-                Memory::CSharedPointer<Signal::CSignal> lazyDisconnect;
-            } m_sEvents;
+            Memory::CSharedPointer<SAnimVarEvents> m_events;
 
             friend class CBaseAnimatedVariable;
         };

--- a/include/hyprutils/animation/AnimationManager.hpp
+++ b/include/hyprutils/animation/AnimationManager.hpp
@@ -44,11 +44,11 @@ namespace Hyprutils {
             bool                                                                  m_bTickScheduled = false;
 
             void                                                                  connectListener(std::any data);
-            void                                                                  forceDisconnectListener(std::any data);
+            void                                                                  disconnectListener(std::any data);
 
             struct {
                 Signal::CHyprSignalListener connect;
-                Signal::CHyprSignalListener forceDisconnect;
+                Signal::CHyprSignalListener disconnect;
             } m_sListeners;
 
             friend class CBaseAnimatedVariable;

--- a/include/hyprutils/animation/AnimationManager.hpp
+++ b/include/hyprutils/animation/AnimationManager.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "./BezierCurve.hpp"
-#include "./AnimatedVariable.hpp"
 #include "../math/Vector2D.hpp"
 #include "../memory/WeakPtr.hpp"
 #include "../signal/Signal.hpp"
@@ -12,6 +11,8 @@
 
 namespace Hyprutils {
     namespace Animation {
+        class CBaseAnimatedVariable;
+
         /* A class for managing bezier curves and variables that are being animated. */
         class CAnimationManager {
           public:
@@ -33,25 +34,30 @@ namespace Hyprutils {
 
             const std::unordered_map<std::string, Memory::CSharedPointer<CBezierCurve>>& getAllBeziers();
 
-            Memory::CSharedPointer<SAnimVarEvents>                                       getEvents() const;
+            struct SAnimationManagerSignals {
+                Signal::CSignal connect;    // WP<CBaseAnimatedVariable>
+                Signal::CSignal disconnect; // WP<CBaseAnimatedVariable>
+            };
 
-            std::vector<Memory::CWeakPointer<CBaseAnimatedVariable>>                     m_vActiveAnimatedVariables;
-            Memory::CSharedPointer<SAnimVarEvents>                                       m_events;
+            Memory::CWeakPointer<SAnimationManagerSignals>           getSignals() const;
+
+            std::vector<Memory::CWeakPointer<CBaseAnimatedVariable>> m_vActiveAnimatedVariables;
 
           private:
             std::unordered_map<std::string, Memory::CSharedPointer<CBezierCurve>> m_mBezierCurves;
 
             bool                                                                  m_bTickScheduled = false;
 
-            void                                                                  connectListener(std::any data);
-            void                                                                  disconnectListener(std::any data);
+            void                                                                  onConnect(std::any data);
+            void                                                                  onDisconnect(std::any data);
 
-            struct {
+            struct SAnimVarListeners {
                 Signal::CHyprSignalListener connect;
                 Signal::CHyprSignalListener disconnect;
-            } m_sListeners;
+            };
 
-            friend class CBaseAnimatedVariable;
+            Memory::CUniquePointer<SAnimVarListeners>        m_listeners;
+            Memory::CUniquePointer<SAnimationManagerSignals> m_events;
         };
     }
 }

--- a/src/animation/AnimatedVariable.cpp
+++ b/src/animation/AnimatedVariable.cpp
@@ -8,13 +8,11 @@ using namespace Hyprutils::Memory;
 #define SP CSharedPointer
 #define WP CWeakPointer
 
-void CBaseAnimatedVariable::create(Hyprutils::Animation::CAnimationManager* pAnimationManager, int typeInfo, SP<CBaseAnimatedVariable> pSelf) {
-    m_pAnimationManager = pAnimationManager;
-    m_Type              = typeInfo;
-    m_pSelf             = pSelf;
+void CBaseAnimatedVariable::create(int typeInfo, SP<CBaseAnimatedVariable> pSelf, SP<SAnimVarEvents> events) {
+    m_Type  = typeInfo;
+    m_pSelf = pSelf;
 
-    m_events = pAnimationManager->m_events;
-
+    m_events = events;
     m_bDummy = false;
 }
 
@@ -77,15 +75,9 @@ float CBaseAnimatedVariable::getPercent() const {
     return 1.f;
 }
 
-float CBaseAnimatedVariable::getCurveValue() const {
-    if (!m_bIsBeingAnimated || !m_pAnimationManager)
+float CBaseAnimatedVariable::getCurveValue(CAnimationManager* pAnimationManager) const {
+    if (!m_bIsBeingAnimated || !pAnimationManager)
         return 1.f;
-
-    // Guard against m_pAnimationManager being deleted
-    // TODO: Remove this and m_pAnimationManager
-    if (m_events.expired()) {
-        return 1.f;
-    }
 
     std::string bezierName = "";
     if (const auto PCONFIG = m_pConfig.lock()) {
@@ -94,7 +86,7 @@ float CBaseAnimatedVariable::getCurveValue() const {
             bezierName = PVALUES->internalBezier;
     }
 
-    const auto BEZIER = m_pAnimationManager->getBezier(bezierName);
+    const auto BEZIER = pAnimationManager->getBezier(bezierName);
     if (!BEZIER)
         return 1.f;
 

--- a/src/animation/AnimatedVariable.cpp
+++ b/src/animation/AnimatedVariable.cpp
@@ -28,7 +28,7 @@ void CBaseAnimatedVariable::connectToActive() {
 
 void CBaseAnimatedVariable::disconnectFromActive() {
     if (const auto PEVENTS = m_events.lock())
-        PEVENTS->forceDisconnect.emit(static_cast<void*>(this));
+        PEVENTS->disconnect.emit(static_cast<void*>(this));
 
     m_bIsConnectedToActive = false;
 }
@@ -133,9 +133,7 @@ void CBaseAnimatedVariable::resetAllCallbacks() {
 
 void CBaseAnimatedVariable::onAnimationEnd() {
     m_bIsBeingAnimated = false;
-    /* lazy disconnect, since this animvar is atill alive */
-    if (const auto PEVENTS = m_events.lock())
-        PEVENTS->lazyDisconnect.emit(static_cast<void*>(this));
+    /* We do not call disconnectFromActive here. The animation manager will remove it on a call to tickDone. */
 
     if (m_fEndCallback) {
         /* loading m_bRemoveEndAfterRan before calling the callback allows the callback to delete this animation safely if it is false. */

--- a/src/animation/AnimationManager.cpp
+++ b/src/animation/AnimationManager.cpp
@@ -16,8 +16,8 @@ CAnimationManager::CAnimationManager() {
 
     m_events = makeShared<SAnimVarEvents>();
 
-    m_sListeners.connect         = m_events->connect.registerListener([this](std::any data) { connectListener(data); });
-    m_sListeners.forceDisconnect = m_events->forceDisconnect.registerListener([this](std::any data) { forceDisconnectListener(data); });
+    m_sListeners.connect    = m_events->connect.registerListener([this](std::any data) { connectListener(data); });
+    m_sListeners.disconnect = m_events->disconnect.registerListener([this](std::any data) { disconnectListener(data); });
 }
 
 void CAnimationManager::connectListener(std::any data) {
@@ -33,7 +33,7 @@ void CAnimationManager::connectListener(std::any data) {
     } catch (const std::bad_any_cast&) { return; }
 }
 
-void CAnimationManager::forceDisconnectListener(std::any data) {
+void CAnimationManager::disconnectListener(std::any data) {
     try {
         const auto PAV = std::any_cast<void*>(data);
         if (!PAV)

--- a/src/animation/AnimationManager.cpp
+++ b/src/animation/AnimationManager.cpp
@@ -14,13 +14,11 @@ CAnimationManager::CAnimationManager() {
     BEZIER->setup(DEFAULTBEZIERPOINTS);
     m_mBezierCurves["default"] = BEZIER;
 
-    m_sEvents.connect         = makeShared<CSignal>();
-    m_sEvents.forceDisconnect = makeShared<CSignal>();
-    m_sEvents.lazyDisconnect  = makeShared<CSignal>();
+    m_events = makeShared<SAnimVarEvents>();
 
-    m_sListeners.connect         = m_sEvents.connect->registerListener([this](std::any data) { connectListener(data); });
-    m_sListeners.forceDisconnect = m_sEvents.forceDisconnect->registerListener([this](std::any data) { forceDisconnectListener(data); });
-    m_sListeners.lazyDisconnect  = m_sEvents.lazyDisconnect->registerListener([this](std::any data) { lazyDisconnectListener(data); });
+    m_sListeners.connect         = m_events->connect.registerListener([this](std::any data) { connectListener(data); });
+    m_sListeners.forceDisconnect = m_events->forceDisconnect.registerListener([this](std::any data) { forceDisconnectListener(data); });
+    m_sListeners.lazyDisconnect  = m_events->lazyDisconnect.registerListener([this](std::any data) { lazyDisconnectListener(data); });
 }
 
 void CAnimationManager::connectListener(std::any data) {

--- a/tests/animation.cpp
+++ b/tests/animation.cpp
@@ -93,7 +93,7 @@ class CMyAnimationManager : public CAnimationManager {
         constexpr const eAVTypes EAVTYPE = std::is_same_v<VarType, int> ? eAVTypes::INT : eAVTypes::TEST;
         const auto               PAV     = makeShared<CGenericAnimatedVariable<VarType, EmtpyContext>>();
 
-        PAV->create(EAVTYPE, PAV, m_events, v);
+        PAV->create(EAVTYPE, static_cast<CAnimationManager*>(this), PAV, v);
         PAV->setConfig(animationTree.getConfig(animationConfigName));
         av = std::move(PAV);
     }
@@ -339,9 +339,9 @@ int main(int argc, char** argv, char** envp) {
 
     // test getCurveValue
     *s.m_iA = 0;
-    EXPECT(s.m_iA->getCurveValue(pAnimationManager.get()), 0.f);
+    EXPECT(s.m_iA->getCurveValue(), 0.f);
     s.m_iA->warp();
-    EXPECT(s.m_iA->getCurveValue(pAnimationManager.get()), 1.f);
+    EXPECT(s.m_iA->getCurveValue(), 1.f);
     EXPECT(endCallbackRan, 6);
 
     // Test duplicate active anim vars are not allowed
@@ -365,6 +365,7 @@ int main(int argc, char** argv, char** envp) {
         pAnimationManager->createAnimation(1, a, "default");
         *a = 10;
         pAnimationManager.reset();
+        EXPECT(a->isAnimationManagerDead(), true);
         a->setValueAndWarp(11);
         EXPECT(a->value(), 11);
         *a = 12;


### PR DESCRIPTION
Thanks a lot to @gulafaran and @vaxerski for debugging and finding the crash.
The first commit here adds a test for it.

The rest of the patch is an alternative to resetting the `pAnimationManager` pointer with a signal, when it gets deleted.

Instead i thought it would be better to just use signals for connect/disconnect in the first place. That removes the need for storing the pointer to pAnimationManager. (We still need it for getCurveValue, but in a next abi breaking change, we could remove it. For now it is guarded by the reference to the events)

And then there seems to be a problem with a growing active vars vector.
I think it happens in Hyprland when we are not ticking and thus not cleaning up active vars. So this adds a `lazyDisconnect` method that just increments an integer. If we want to add a new var and this integer is > 100, we manually trigger a cleanup.

I also have no problem in reverting the removal of vars to how it worked before moving the anim stuf to hyprutils. (always using forceDisconnect and making sure we are not calling it during tick.) That would be the alternative to the `lazyDisconnect` thing.

~~Should not break ABI.~~ Breaks ABI