### PR TITLE
animation: fix end callbacks readding the animation var

### DIFF
--- a/include/hyprutils/animation/AnimatedVariable.hpp
+++ b/include/hyprutils/animation/AnimatedVariable.hpp
@@ -160,11 +160,11 @@ namespace Hyprutils {
 
                 m_bIsBeingAnimated = false;
 
-                if (endCallback)
-                    onAnimationEnd();
-
                 if (forceDisconnect)
                     disconnectFromActive();
+
+                if (endCallback)
+                    onAnimationEnd();
             }
 
             const VarType& value() const {

--- a/include/hyprutils/animation/AnimationConfig.hpp
+++ b/include/hyprutils/animation/AnimationConfig.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../memory/WeakPtr.hpp"
-#include "hyprutils/memory/WeakPtr.hpp"
 
 #include <string>
 #include <unordered_map>

--- a/src/animation/AnimatedVariable.cpp
+++ b/src/animation/AnimatedVariable.cpp
@@ -13,8 +13,8 @@ void CBaseAnimatedVariable::create(CAnimationManager* pManager, int typeInfo, SP
     m_pSelf = pSelf;
 
     m_pAnimationManager = pManager;
-    m_pSignals = pManager->getSignals();
-    m_bDummy   = false;
+    m_pSignals          = pManager->getSignals();
+    m_bDummy            = false;
 }
 
 void CBaseAnimatedVariable::connectToActive() {
@@ -136,11 +136,12 @@ void CBaseAnimatedVariable::onAnimationEnd() {
     /* We do not call disconnectFromActive here. The animation manager will remove it on a call to tickDone. */
 
     if (m_fEndCallback) {
-        /* loading m_bRemoveEndAfterRan before calling the callback allows the callback to delete this animation safely if it is false. */
-        auto removeEndCallback = m_bRemoveEndAfterRan;
-        m_fEndCallback(m_pSelf);
-        if (removeEndCallback)
-            m_fEndCallback = nullptr; // reset
+        CallbackFun cb = nullptr;
+        m_fEndCallback.swap(cb);
+
+        cb(m_pSelf);
+        if (!m_bRemoveEndAfterRan && /* callback did not set a new one by itself */ !m_fEndCallback)
+            m_fEndCallback = cb; // restore
     }
 }
 

--- a/tests/animation.cpp
+++ b/tests/animation.cpp
@@ -344,6 +344,23 @@ int main(int argc, char** argv, char** envp) {
     EXPECT(s.m_iA->getCurveValue(), 1.f);
     EXPECT(endCallbackRan, 6);
 
+    // test end callback readding the var
+    *s.m_iA = 5;
+    s.m_iA->setCallbackOnEnd([&endCallbackRan](WP<CBaseAnimatedVariable> v) {
+        endCallbackRan++;
+        const auto PAV = dynamic_cast<CAnimatedVariable<int>*>(v.lock().get());
+
+        *PAV = 10;
+        PAV->setCallbackOnEnd([&endCallbackRan](WP<CBaseAnimatedVariable> v) { endCallbackRan++; });
+    });
+
+    while (pAnimationManager->shouldTickForNext()) {
+        pAnimationManager->tick();
+    }
+
+    EXPECT(endCallbackRan, 8);
+    EXPECT(s.m_iA->value(), 10);
+
     // Test duplicate active anim vars are not allowed
     {
         EXPECT(pAnimationManager->m_vActiveAnimatedVariables.size(), 0);


### PR DESCRIPTION
Since last PR a callback on end would not be able to re-add the current var when called via warp, cause disconnectFromActive would be called after the callback.

This fixes it and adds a test for that.
No ABI breakage :) 