### PR TITLE
core: clang, clang-tidy fixes and comp options

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,101 @@
+WarningsAsErrors: '*'
+HeaderFilterRegex: '.*\.hpp'
+FormatStyle: file
+Checks: >
+  -*,
+  bugprone-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-forward-declararion-namespace,
+  -bugprone-forward-declararion-namespace,
+  -bugprone-macro-parentheses,
+  -bugprone-narrowing-conversions,
+  -bugprone-branch-clone,
+  -bugprone-assignment-in-if-condition,
+  concurrency-*,
+  -concurrency-mt-unsafe,
+  cppcoreguidelines-*,
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
+  -cppcoreguidelines-avoid-const-or-ref-data-members,
+  -cppcoreguidelines-non-private-member-variables-in-classes,
+  -cppcoreguidelines-avoid-goto,
+  -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-avoid-do-while,
+  -cppcoreguidelines-avoid-non-const-global-variables,
+  -cppcoreguidelines-special-member-functions,
+  -cppcoreguidelines-explicit-virtual-functions,
+  -cppcoreguidelines-avoid-c-arrays,
+  -cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  -cppcoreguidelines-narrowing-conversions,
+  -cppcoreguidelines-pro-type-union-access,
+  -cppcoreguidelines-pro-type-member-init,
+  -cppcoreguidelines-macro-usage,
+  -cppcoreguidelines-macro-to-enum,
+  -cppcoreguidelines-init-variables,
+  -cppcoreguidelines-pro-type-cstyle-cast,
+  -cppcoreguidelines-pro-type-vararg,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
+  google-global-names-in-headers,
+  -google-readability-casting,
+  google-runtime-operator,
+  misc-*,
+  -misc-unused-parameters,
+  -misc-no-recursion,
+  -misc-non-private-member-variables-in-classes,
+  -misc-include-cleaner,
+  -misc-use-anonymous-namespace,
+  -misc-const-correctness,
+  modernize-*,
+  -modernize-return-braced-init-list,
+  -modernize-use-trailing-return-type,
+  -modernize-use-using,
+  -modernize-use-override,
+  -modernize-avoid-c-arrays,
+  -modernize-macro-to-enum,
+  -modernize-loop-convert,
+  -modernize-use-nodiscard,
+  -modernize-pass-by-value,
+  -modernize-use-auto,
+  performance-*,
+  -performance-avoid-endl,
+  -performance-unnecessary-value-param,
+  portability-std-allocator-const,
+  readability-*,
+  -readability-function-cognitive-complexity,
+  -readability-function-size,
+  -readability-identifier-length,
+  -readability-magic-numbers,
+  -readability-uppercase-literal-suffix,
+  -readability-braces-around-statements,
+  -readability-redundant-access-specifiers,
+  -readability-else-after-return,
+  -readability-container-data-pointer,
+  -readability-implicit-bool-conversion,
+  -readability-avoid-nested-conditional-operator,
+  -readability-redundant-member-init,
+  -readability-redundant-string-init,
+  -readability-avoid-const-params-in-decls,
+  -readability-named-parameter,
+  -readability-convert-member-functions-to-static,
+  -readability-qualified-auto,
+  -readability-make-member-function-const,
+  -readability-isolate-declaration,
+  -readability-inconsistent-declaration-parameter-name,
+  -clang-diagnostic-error,
+
+CheckOptions:
+  performance-for-range-copy.WarnOnAllAutoCopies: true
+  performance-inefficient-string-concatenation.StrictMode: true
+  readability-braces-around-statements.ShortStatementLines: 0
+  readability-identifier-naming.ClassCase: CamelCase
+  readability-identifier-naming.ClassIgnoredRegexp: I.*
+  readability-identifier-naming.ClassPrefix: C # We can't use regex here?!?!?!?
+  readability-identifier-naming.EnumCase: CamelCase
+  readability-identifier-naming.EnumPrefix: e
+  readability-identifier-naming.EnumConstantCase: UPPER_CASE
+  readability-identifier-naming.FunctionCase: camelBack
+  readability-identifier-naming.NamespaceCase: CamelCase
+  readability-identifier-naming.NamespacePrefix: N
+  readability-identifier-naming.StructPrefix: S
+  readability-identifier-naming.StructCase: CamelCase

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,16 @@ set(LIBDIR ${CMAKE_INSTALL_FULL_LIBDIR})
 configure_file(hyprutils.pc.in hyprutils.pc @ONLY)
 
 set(CMAKE_CXX_STANDARD 23)
+add_compile_options(
+  -Wall
+  -Wextra
+  -Wpedantic
+  -Wno-unused-parameter
+  -Wno-unused-value
+  -Wno-missing-field-initializers
+  -Wno-narrowing
+  -Wno-pointer-arith)
+set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES DEBUG)
   message(STATUS "Configuring hyprutils in Debug")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,8 @@ add_compile_options(
   -Wno-unused-value
   -Wno-missing-field-initializers
   -Wno-narrowing
-  -Wno-pointer-arith)
+  -Wno-pointer-arith
+  -Wno-reorder)
 set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug OR CMAKE_BUILD_TYPE MATCHES DEBUG)

--- a/src/animation/AnimationManager.cpp
+++ b/src/animation/AnimationManager.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <hyprutils/animation/AnimationManager.hpp>
 #include <hyprutils/animation/AnimatedVariable.hpp>
 
@@ -99,7 +100,7 @@ bool CAnimationManager::bezierExists(const std::string& bezier) {
 }
 
 SP<CBezierCurve> CAnimationManager::getBezier(const std::string& name) {
-    const auto BEZIER = std::find_if(m_mBezierCurves.begin(), m_mBezierCurves.end(), [&](const auto& other) { return other.first == name; });
+    const auto BEZIER = std::ranges::find_if(m_mBezierCurves, [&](const auto& other) { return other.first == name; });
 
     return BEZIER == m_mBezierCurves.end() ? m_mBezierCurves["default"] : BEZIER->second;
 }

--- a/src/animation/BezierCurve.cpp
+++ b/src/animation/BezierCurve.cpp
@@ -35,14 +35,14 @@ float CBezierCurve::getXForT(float const& t) const {
     float t2 = t * t;
     float t3 = t2 * t;
 
-    return 3 * t * (1 - t) * (1 - t) * m_vPoints[1].x + 3 * t2 * (1 - t) * m_vPoints[2].x + t3 * m_vPoints[3].x;
+    return (3 * t * (1 - t) * (1 - t) * m_vPoints[1].x) + (3 * t2 * (1 - t) * m_vPoints[2].x) + (t3 * m_vPoints[3].x);
 }
 
 float CBezierCurve::getYForT(float const& t) const {
     float t2 = t * t;
     float t3 = t2 * t;
 
-    return 3 * t * (1 - t) * (1 - t) * m_vPoints[1].y + 3 * t2 * (1 - t) * m_vPoints[2].y + t3 * m_vPoints[3].y;
+    return (3 * t * (1 - t) * (1 - t) * m_vPoints[1].y) + (3 * t2 * (1 - t) * m_vPoints[2].y) + (t3 * m_vPoints[3].y);
 }
 
 // Todo: this probably can be done better and faster
@@ -74,5 +74,5 @@ float CBezierCurve::getYForPoint(float const& x) const {
     if (std::isnan(PERCINDELTA) || std::isinf(PERCINDELTA)) // can sometimes happen for VERY small x
         return 0.f;
 
-    return LOWERPOINT->y + (UPPERPOINT->y - LOWERPOINT->y) * PERCINDELTA;
+    return LOWERPOINT->y + ((UPPERPOINT->y - LOWERPOINT->y) * PERCINDELTA);
 }

--- a/src/math/Box.cpp
+++ b/src/math/Box.cpp
@@ -37,7 +37,7 @@ CBox& Hyprutils::Math::CBox::translate(const Vector2D& vec) {
 }
 
 Vector2D Hyprutils::Math::CBox::middle() const {
-    return Vector2D{x + w * HALF, y + h * HALF};
+    return Vector2D{x + (w * HALF), y + (h * HALF)};
 }
 
 bool Hyprutils::Math::CBox::containsPoint(const Vector2D& vec) const {
@@ -233,5 +233,5 @@ Vector2D Hyprutils::Math::CBox::closestPoint(const Vector2D& vec) const {
 }
 
 SBoxExtents Hyprutils::Math::CBox::extentsFrom(const CBox& small) {
-    return {{small.x - x, small.y - y}, {w - small.w - (small.x - x), h - small.h - (small.y - y)}};
+    return {.topLeft = {small.x - x, small.y - y}, .bottomRight = {w - small.w - (small.x - x), h - small.h - (small.y - y)}};
 }

--- a/src/math/Region.cpp
+++ b/src/math/Region.cpp
@@ -86,7 +86,7 @@ CRegion& Hyprutils::Math::CRegion::invert(pixman_box32_t* box) {
 }
 
 CRegion& Hyprutils::Math::CRegion::invert(const CBox& box) {
-    pixman_box32 pixmanBox = {(int32_t)box.x, (int32_t)box.y, (int32_t)box.w + (int32_t)box.x, (int32_t)box.h + (int32_t)box.y};
+    pixman_box32 pixmanBox = {.x1 = (int32_t)box.x, .y1 = (int32_t)box.y, .x2 = (int32_t)box.w + (int32_t)box.x, .y2 = (int32_t)box.h + (int32_t)box.y};
     return this->invert(&pixmanBox);
 }
 
@@ -118,7 +118,7 @@ CRegion& Hyprutils::Math::CRegion::expand(double units) {
     clear();
 
     for (auto& r : rects) {
-        CBox b{(double)r.x1 - units, (double)r.y1 - units, (double)r.x2 - r.x1 + units * 2, (double)r.y2 - r.y1 + units * 2};
+        CBox b{(double)r.x1 - units, (double)r.y1 - units, (double)r.x2 - r.x1 + (units * 2), (double)r.y2 - r.y1 + (units * 2)};
         add(b);
     }
 

--- a/src/math/Vector2D.cpp
+++ b/src/math/Vector2D.cpp
@@ -4,19 +4,16 @@
 
 using namespace Hyprutils::Math;
 
-Hyprutils::Math::Vector2D::Vector2D(double xx, double yy) {
-    x = xx;
-    y = yy;
+Hyprutils::Math::Vector2D::Vector2D(double xx, double yy) : x(xx), y(yy) {
+    ;
 }
 
-Hyprutils::Math::Vector2D::Vector2D(int xx, int yy) {
-    x = (double)xx;
-    y = (double)yy;
+Hyprutils::Math::Vector2D::Vector2D(int xx, int yy) : x((double)xx), y((double)yy) {
+    ;
 }
 
-Hyprutils::Math::Vector2D::Vector2D() {
-    x = 0;
-    y = 0;
+Hyprutils::Math::Vector2D::Vector2D() : x(0), y(0) {
+    ;
 }
 
 Hyprutils::Math::Vector2D::~Vector2D() {}
@@ -48,11 +45,11 @@ double Hyprutils::Math::Vector2D::distance(const Vector2D& other) const {
 }
 
 double Hyprutils::Math::Vector2D::distanceSq(const Vector2D& other) const {
-    return (x - other.x) * (x - other.x) + (y - other.y) * (y - other.y);
+    return ((x - other.x) * (x - other.x)) + ((y - other.y) * (y - other.y));
 }
 
 double Hyprutils::Math::Vector2D::size() const {
-    return std::sqrt(x * x + y * y);
+    return std::sqrt((x * x) + (y * y));
 }
 
 Vector2D Hyprutils::Math::Vector2D::getComponentMax(const Vector2D& other) const {

--- a/src/os/FileDescriptor.cpp
+++ b/src/os/FileDescriptor.cpp
@@ -37,10 +37,7 @@ int CFileDescriptor::getFlags() const {
 }
 
 bool CFileDescriptor::setFlags(int flags) {
-    if (fcntl(m_fd, F_SETFD, flags) == -1)
-        return false;
-
-    return true;
+    return fcntl(m_fd, F_SETFD, flags) != -1;
 }
 
 int CFileDescriptor::take() {

--- a/src/os/Process.cpp
+++ b/src/os/Process.cpp
@@ -171,7 +171,7 @@ bool Hyprutils::OS::CProcess::runAsync() {
         // run in child
         sigset_t set;
         sigemptyset(&set);
-        sigprocmask(SIG_SETMASK, &set, NULL);
+        sigprocmask(SIG_SETMASK, &set, nullptr);
 
         grandchild = fork();
         if (grandchild == 0) {

--- a/src/path/Path.cpp
+++ b/src/path/Path.cpp
@@ -62,7 +62,7 @@ namespace Hyprutils::Path {
 
         static const auto xdgConfigDirs = getXdgConfigDirs();
         if (xdgConfigDirs.has_value()) {
-            for (auto dir : xdgConfigDirs.value()) {
+            for (auto &dir : xdgConfigDirs.value()) {
                 if (checkConfigExists(dir, programName))
                     return std::make_pair(fullConfigPath(dir, programName), std::nullopt);
             }

--- a/src/path/Path.cpp
+++ b/src/path/Path.cpp
@@ -62,7 +62,7 @@ namespace Hyprutils::Path {
 
         static const auto xdgConfigDirs = getXdgConfigDirs();
         if (xdgConfigDirs.has_value()) {
-            for (auto &dir : xdgConfigDirs.value()) {
+            for (auto& dir : xdgConfigDirs.value()) {
                 if (checkConfigExists(dir, programName))
                     return std::make_pair(fullConfigPath(dir, programName), std::nullopt);
             }

--- a/src/signal/Signal.cpp
+++ b/src/signal/Signal.cpp
@@ -18,6 +18,7 @@ void Hyprutils::Signal::CSignal::emit(std::any data) {
     }
 
     std::vector<CStaticSignalListener*> statics;
+    statics.reserve(m_vStaticListeners.size());
     for (auto& l : m_vStaticListeners) {
         statics.emplace_back(l.get());
     }

--- a/src/string/String.cpp
+++ b/src/string/String.cpp
@@ -7,12 +7,12 @@ std::string Hyprutils::String::trim(const std::string& in) {
     if (in.empty())
         return in;
 
-    int countBefore = 0;
+    size_t countBefore = 0;
     while (countBefore < in.length() && std::isspace(in.at(countBefore))) {
         countBefore++;
     }
 
-    int countAfter = 0;
+    size_t countAfter = 0;
     while (countAfter < in.length() - countBefore && std::isspace(in.at(in.length() - countAfter - 1))) {
         countAfter++;
     }
@@ -55,10 +55,7 @@ bool Hyprutils::String::isNumber(const std::string& str, bool allowfloat) {
         }
     }
 
-    if (!isdigit(str.back()))
-        return false;
-
-    return true;
+    return isdigit(str.back()) != 0;
 }
 
 void Hyprutils::String::replaceInString(std::string& string, const std::string& what, const std::string& to) {

--- a/src/string/VarList.cpp
+++ b/src/string/VarList.cpp
@@ -22,7 +22,7 @@ Hyprutils::String::CVarList::CVarList(const std::string& in, const size_t lastAr
             break;
         }
         pos += s.size() + 1;
-        m_vArgs.emplace_back(trim(std::string_view{s}.data()));
+        m_vArgs.emplace_back(trim(s.data()));
     }
 }
 


### PR DESCRIPTION
Now i tried it without breaking ABI
And added some comp options
Breaking ABI will be in the next PR with the warnings fix
There's 30 of them. Reorder for now will be silenced