### PR TITLE
FileDescriptor: provide fallback if F_DUPFD_CLOEXEC is undefined

### DIFF
--- a/include/hyprutils/os/FileDescriptor.hpp
+++ b/include/hyprutils/os/FileDescriptor.hpp
@@ -1,6 +1,11 @@
 #pragma once
 
 #include <fcntl.h>
+
+#ifndef F_DUPFD_CLOEXEC
+#define F_DUPFD_CLOEXEC F_DUPFD
+#endif
+
 namespace Hyprutils {
     namespace OS {
         class CFileDescriptor {

--- a/src/os/FileDescriptor.cpp
+++ b/src/os/FileDescriptor.cpp
@@ -55,7 +55,14 @@ CFileDescriptor CFileDescriptor::duplicate(int flags) const {
     if (m_fd == -1)
         return {};
 
-    return CFileDescriptor{fcntl(m_fd, flags, 0)};
+    int new_fd;
+#ifdef F_DUPFD_CLOEXEC
+    new_fd = fcntl(m_fd, flags, 0);
+#else
+    new_fd = fcntl(m_fd, flags | FD_CLOEXEC, 0);
+#endif
+
+    return CFileDescriptor{new_fd};
 }
 
 bool CFileDescriptor::isClosed() const {


### PR DESCRIPTION
`F_DUPFD_CLOEXEC` is not guaranteed to be available.