### PR TITLE
include/hyprutils/memory/SharedPtr.hpp: include missing <cstdint>

### DIFF
--- a/include/hyprutils/memory/SharedPtr.hpp
+++ b/include/hyprutils/memory/SharedPtr.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdint>
 
 #include "ImplBase.hpp"
 


### PR DESCRIPTION
Without the change the build on upcoming gcc-16 fails as:

    [ 12%] Building CXX object CMakeFiles/hyprutils.dir/src/signal/Listener.cpp.o
    In file included from /build/source/./include/hyprutils/signal/Listener.hpp:5,
                     from /build/source/src/signal/Listener.cpp:1:
    /build/source/./include/hyprutils/memory/SharedPtr.hpp: In member function 'bool Hyprutils::Memory::CSharedPointer<T>::operator()(const Hyprutils::Memory::CSharedPointer<T>&, const Hyprutils::Memory::CSharedPointer<T>&) const':
    /build/source/./include/hyprutils/memory/SharedPtr.hpp:116:41: error: 'uintptr_t' does not name a type [-Wtemplate-body]
      116 |                 return reinterpret_cast<uintptr_t>(lhs.impl_) < reinterpret_cast<uintptr_t>(rhs.impl_);
          |                                         ^~~~~~~~~