### PR TITLE
nix: use gcc15

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734119587,
-        "narHash": "sha256-AKU6qqskl0yf2+JdRdD0cfxX4b9x3KKV5RqA6wijmPM=",
+        "lastModified": 1748929857,
+        "narHash": "sha256-lcZQ8RhsmhsK8u7LIFsJhsLh/pzR9yZ8yqpTzyGdj+Q=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3566ab7246670a43abd2ffa913cc62dad9cdf7d5",
+        "rev": "c2a03962b8e24e669fb37b7df10e7c79531ff1a4",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
       default = self.overlays.hyprutils;
       hyprutils = final: prev: {
         hyprutils = final.callPackage ./nix/default.nix {
-          stdenv = final.gcc14Stdenv;
+          stdenv = final.gcc15Stdenv;
           version = version + "+date=" + (mkDate (self.lastModifiedDate or "19700101")) + "_" + (self.shortRev or "dirty");
         };
         hyprutils-with-tests = final.hyprutils.override {doCheck = true;};


### PR DESCRIPTION
changed `gcc14Stdenv` to `gcc15Stdenv` for nix, to match hyprland

(fixes https://github.com/hyprwm/Hyprland/discussions/10622)

updated nixpkgs in flake.lock for gcc15 to be available

(hyprland would need to update flake.lock dependency afterwards as well)