### PR TITLE
implbase: include cstdint and fix building with GCC 16

### DIFF
--- a/include/hyprutils/memory/ImplBase.hpp
+++ b/include/hyprutils/memory/ImplBase.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 
 namespace Hyprutils {


### PR DESCRIPTION
Without cstdint, building with GCC 16 fails with error

```
In file included from /tmp/hyprutils/tests/memory.cpp:1: /tmp/hyprutils/./include/hyprutils/memory/UniquePtr.hpp: In member function ‘bool Hyprutils::Memory::CUniquePointer<T>::operator()(const Hyprutils: :Memory::CUniquePointer<T>&, const Hyprutils::Memory::CUniquePointer<T>&) const’: /tmp/hyprutils/./include/hyprutils/memory/UniquePtr.hpp:77:41: error: ‘uintptr_t’ does not name a type [-Wtemplate-body]
   77 |                 return reinterpret_cast<uintptr_t>(lhs.impl_) < reinterpret_cast<uintptr_t>(rhs.impl_);
      |                                         ^~~~~~~~~
/tmp/hyprutils/./include/hyprutils/memory/UniquePtr.hpp:4:1: note: ‘uintptr_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding
 ‘#include <cstdint>’
    3 | #include "ImplBase.hpp"
  +++ |+#include <cstdint>
    4 |
/tmp/hyprutils/./include/hyprutils/memory/UniquePtr.hpp:77:82: error: ‘uintptr_t’ does not name a type [-Wtemplate-body]
   77 |                 return reinterpret_cast<uintptr_t>(lhs.impl_) < reinterpret_cast<uintptr_t>(rhs.impl_);
      |                                                                                  ^~~~~~~~~
/tmp/hyprutils/./include/hyprutils/memory/UniquePtr.hpp:77:82: note: ‘uintptr_t’ is defined in header ‘<cstdint>’; this is probably fixable by addi
ng ‘#include <cstdint>’
```

Downstream-bug: https://bugs.gentoo.org/957409