### PR TITLE
introduce CRegion foreach and cleanup clangd warnings

### DIFF
--- a/include/hyprutils/math/Region.hpp
+++ b/include/hyprutils/math/Region.hpp
@@ -21,17 +21,21 @@ namespace Hyprutils {
             CRegion(pixman_box32_t* box);
 
             CRegion(const CRegion&);
-            CRegion(CRegion&&);
+            CRegion(CRegion&&) noexcept;
 
             ~CRegion();
 
-            CRegion& operator=(CRegion&& other) {
-                pixman_region32_copy(&m_rRegion, other.pixman());
+            CRegion& operator=(CRegion&& other) noexcept {
+                if (this != &other)
+                    pixman_region32_copy(&m_rRegion, other.pixman());
+
                 return *this;
             }
 
-            CRegion& operator=(CRegion& other) {
-                pixman_region32_copy(&m_rRegion, other.pixman());
+            CRegion& operator=(const CRegion& other) {
+                if (this != &other)
+                    pixman_region32_copy(&m_rRegion, other.pixman());
+
                 return *this;
             }
 
@@ -69,6 +73,10 @@ namespace Hyprutils {
 
             //
             pixman_region32_t* pixman() {
+                return &m_rRegion;
+            }
+
+            const pixman_region32_t* pixman() const {
                 return &m_rRegion;
             }
 

--- a/src/math/Region.cpp
+++ b/src/math/Region.cpp
@@ -28,10 +28,10 @@ Hyprutils::Math::CRegion::CRegion(pixman_box32_t* box) {
 
 Hyprutils::Math::CRegion::CRegion(const CRegion& other) {
     pixman_region32_init(&m_rRegion);
-    pixman_region32_copy(&m_rRegion, const_cast<CRegion*>(&other)->pixman());
+    pixman_region32_copy(&m_rRegion, other.pixman());
 }
 
-Hyprutils::Math::CRegion::CRegion(CRegion&& other) {
+Hyprutils::Math::CRegion::CRegion(CRegion&& other) noexcept {
     pixman_region32_init(&m_rRegion);
     pixman_region32_copy(&m_rRegion, other.pixman());
 }
@@ -46,12 +46,12 @@ CRegion& Hyprutils::Math::CRegion::clear() {
 }
 
 CRegion& Hyprutils::Math::CRegion::set(const CRegion& other) {
-    pixman_region32_copy(&m_rRegion, const_cast<CRegion*>(&other)->pixman());
+    pixman_region32_copy(&m_rRegion, other.pixman());
     return *this;
 }
 
 CRegion& Hyprutils::Math::CRegion::add(const CRegion& other) {
-    pixman_region32_union(&m_rRegion, &m_rRegion, const_cast<CRegion*>(&other)->pixman());
+    pixman_region32_union(&m_rRegion, &m_rRegion, other.pixman());
     return *this;
 }
 
@@ -66,12 +66,12 @@ CRegion& Hyprutils::Math::CRegion::add(const CBox& other) {
 }
 
 CRegion& Hyprutils::Math::CRegion::subtract(const CRegion& other) {
-    pixman_region32_subtract(&m_rRegion, &m_rRegion, const_cast<CRegion*>(&other)->pixman());
+    pixman_region32_subtract(&m_rRegion, &m_rRegion, other.pixman());
     return *this;
 }
 
 CRegion& Hyprutils::Math::CRegion::intersect(const CRegion& other) {
-    pixman_region32_intersect(&m_rRegion, &m_rRegion, const_cast<CRegion*>(&other)->pixman());
+    pixman_region32_intersect(&m_rRegion, &m_rRegion, other.pixman());
     return *this;
 }
 


### PR DESCRIPTION
introduce foreach to let us call functions directly on rects instead of allocating and returning a vector in hot paths in hyprland. 

fix a few clangd warnings regarding noexcept, self assignment in move and overload pixman() so we dont have to const_cast