### PR TITLE
few memory fixups

### DIFF
--- a/include/hyprutils/memory/Atomic.hpp
+++ b/include/hyprutils/memory/Atomic.hpp
@@ -50,9 +50,9 @@ namespace Hyprutils::Memory {
     template <typename T>
     class CAtomicSharedPointer {
         template <typename X>
-        using isConstructible = typename std::enable_if<std::is_constructible<T&, X&>::value>::type;
+        using isConstructible = std::enable_if_t<std::is_constructible_v<T&, X&>>;
         template <typename X>
-        using validHierarchy = typename std::enable_if<std::is_assignable<CAtomicSharedPointer<T>&, X>::value, CAtomicSharedPointer&>::type;
+        using validHierarchy = std::enable_if_t<std::is_assignable_v<CAtomicSharedPointer<T>&, X>, CAtomicSharedPointer&>;
 
       public:
         explicit CAtomicSharedPointer(Impl_::impl_base* impl) noexcept : m_ptr(impl) {}
@@ -221,9 +221,9 @@ namespace Hyprutils::Memory {
     class CAtomicWeakPointer {
 
         template <typename X>
-        using isConstructible = typename std::enable_if<std::is_constructible<T&, X&>::value>::type;
+        using isConstructible = std::enable_if_t<std::is_constructible_v<T&, X&>>;
         template <typename X>
-        using validHierarchy = typename std::enable_if<std::is_assignable<CAtomicWeakPointer<T>&, X>::value, CAtomicWeakPointer&>::type;
+        using validHierarchy = std::enable_if_t<std::is_assignable_v<CAtomicWeakPointer<T>&, X>, CAtomicWeakPointer&>;
 
       public:
         CAtomicWeakPointer(const CAtomicWeakPointer<T>& ref) {

--- a/include/hyprutils/memory/ImplBase.hpp
+++ b/include/hyprutils/memory/ImplBase.hpp
@@ -8,7 +8,7 @@ namespace Hyprutils {
         namespace Impl_ {
             class impl_base {
               public:
-                virtual ~impl_base() {};
+                virtual ~impl_base() = default;
 
                 virtual void         inc() noexcept         = 0;
                 virtual void         dec() noexcept         = 0;
@@ -57,13 +57,13 @@ namespace Hyprutils {
                     // this way, weak pointers will still be able to
                     // reference and use, but no longer create shared ones.
                     _destroying = true;
-                    __deleter(_data);
+                    _deleter(_data);
                     // now, we can reset the data and call it a day.
                     _data       = nullptr;
                     _destroying = false;
                 }
 
-                std::default_delete<T> __deleter{};
+                std::default_delete<T> _deleter{};
 
                 //
                 virtual void inc() noexcept {

--- a/include/hyprutils/memory/SharedPtr.hpp
+++ b/include/hyprutils/memory/SharedPtr.hpp
@@ -22,9 +22,9 @@ namespace Hyprutils {
         class CSharedPointer {
           public:
             template <typename X>
-            using validHierarchy = typename std::enable_if<std::is_assignable<CSharedPointer<T>&, X>::value, CSharedPointer&>::type;
+            using validHierarchy = std::enable_if_t<std::is_assignable_v<CSharedPointer<T>&, X>, CSharedPointer&>;
             template <typename X>
-            using isConstructible = typename std::enable_if<std::is_constructible<T&, X&>::value>::type;
+            using isConstructible = std::enable_if_t<std::is_constructible_v<T&, X&>>;
 
             /* creates a new shared pointer managing a resource
                avoid calling. Could duplicate ownership. Prefer makeShared */
@@ -95,7 +95,7 @@ namespace Hyprutils {
                 return *this;
             }
 
-            CSharedPointer& operator=(CSharedPointer&& rhs) {
+            CSharedPointer& operator=(CSharedPointer&& rhs) noexcept {
                 std::swap(impl_, rhs.impl_);
                 return *this;
             }

--- a/include/hyprutils/memory/SharedPtr.hpp
+++ b/include/hyprutils/memory/SharedPtr.hpp
@@ -28,20 +28,17 @@ namespace Hyprutils {
 
             /* creates a new shared pointer managing a resource
                avoid calling. Could duplicate ownership. Prefer makeShared */
-            explicit CSharedPointer(T* object) noexcept {
-                impl_ = new Impl_::impl<T>(object);
+            explicit CSharedPointer(T* object) noexcept : impl_(new Impl_::impl<T>(object)) {
                 increment();
             }
 
             /* creates a shared pointer from a reference */
             template <typename U, typename = isConstructible<U>>
-            CSharedPointer(const CSharedPointer<U>& ref) noexcept {
-                impl_ = ref.impl_;
+            CSharedPointer(const CSharedPointer<U>& ref) noexcept : impl_(ref.impl_) {
                 increment();
             }
 
-            CSharedPointer(const CSharedPointer& ref) noexcept {
-                impl_ = ref.impl_;
+            CSharedPointer(const CSharedPointer& ref) noexcept : impl_(ref.impl_) {
                 increment();
             }
 
@@ -55,8 +52,7 @@ namespace Hyprutils {
             }
 
             /* allows weakPointer to create from an impl */
-            CSharedPointer(Impl_::impl_base* implementation) noexcept {
-                impl_ = implementation;
+            CSharedPointer(Impl_::impl_base* implementation) noexcept : impl_(implementation) {
                 increment();
             }
 

--- a/include/hyprutils/memory/UniquePtr.hpp
+++ b/include/hyprutils/memory/UniquePtr.hpp
@@ -16,9 +16,9 @@ namespace Hyprutils {
         class CUniquePointer {
           public:
             template <typename X>
-            using validHierarchy = typename std::enable_if<std::is_assignable<CUniquePointer<T>&, X>::value, CUniquePointer&>::type;
+            using validHierarchy = std::enable_if_t<std::is_assignable_v<CUniquePointer<T>&, X>, CUniquePointer&>;
             template <typename X>
-            using isConstructible = typename std::enable_if<std::is_constructible<T&, X&>::value>::type;
+            using isConstructible = std::enable_if_t<std::is_constructible_v<T&, X&>>;
 
             /* creates a new unique pointer managing a resource
                avoid calling. Could duplicate ownership. Prefer makeUnique */
@@ -62,7 +62,7 @@ namespace Hyprutils {
                 return *this;
             }
 
-            CUniquePointer& operator=(CUniquePointer&& rhs) {
+            CUniquePointer& operator=(CUniquePointer&& rhs) noexcept {
                 std::swap(impl_, rhs.impl_);
                 return *this;
             }

--- a/include/hyprutils/memory/UniquePtr.hpp
+++ b/include/hyprutils/memory/UniquePtr.hpp
@@ -22,8 +22,7 @@ namespace Hyprutils {
 
             /* creates a new unique pointer managing a resource
                avoid calling. Could duplicate ownership. Prefer makeUnique */
-            explicit CUniquePointer(T* object) noexcept {
-                impl_ = new Impl_::impl<T>(object, false);
+            explicit CUniquePointer(T* object) noexcept : impl_(new Impl_::impl<T>(object, false)) {
                 increment();
             }
 

--- a/include/hyprutils/memory/WeakPtr.hpp
+++ b/include/hyprutils/memory/WeakPtr.hpp
@@ -16,9 +16,9 @@ namespace Hyprutils {
         class CWeakPointer {
           public:
             template <typename X>
-            using validHierarchy = typename std::enable_if<std::is_assignable<CWeakPointer<T>&, X>::value, CWeakPointer&>::type;
+            using validHierarchy = std::enable_if_t<std::is_assignable_v<CWeakPointer<T>&, X>, CWeakPointer&>;
             template <typename X>
-            using isConstructible = typename std::enable_if<std::is_constructible<T&, X&>::value>::type;
+            using isConstructible = std::enable_if_t<std::is_constructible_v<T&, X&>>;
 
             /* create a weak ptr from a reference */
             template <typename U, typename = isConstructible<U>>


### PR DESCRIPTION
use initializer in constructors, for trivial types this is optimized away, non trivial it default constructs and then assigns it upon construction, minor waste. so lets use member initializer for these custom types.

modernize validHierarchy and isConstructible, mark move operator noexcept, use default destructor instead of {}, __deleter is a reserved name, remove a underscore.

as per clangd docs.
The C standard additionally reserves names beginning with a double underscore,
while the C++ standard strengthens this to reserve names with a double underscore occurring anywhere.

these changes should be ABI safe, API is depending on how you see it changing? because __deleter is now _deleter but i doubt anything really used it outside of impl_base.