### PR TITLE
memory: make SP/ASP control blocks type agnostic

### DIFF
--- a/include/hyprutils/memory/ImplBase.hpp
+++ b/include/hyprutils/memory/ImplBase.hpp
@@ -8,44 +8,71 @@ namespace Hyprutils {
         namespace Impl_ {
             class impl_base {
               public:
-                virtual ~impl_base() = default;
+                using DeleteFn = void (*)(void*);
 
-                virtual void         inc() noexcept         = 0;
-                virtual void         dec() noexcept         = 0;
-                virtual void         incWeak() noexcept     = 0;
-                virtual void         decWeak() noexcept     = 0;
-                virtual unsigned int ref() noexcept         = 0;
-                virtual unsigned int wref() noexcept        = 0;
-                virtual void         destroy() noexcept     = 0;
-                virtual bool         destroying() noexcept  = 0;
-                virtual bool         dataNonNull() noexcept = 0;
-                virtual bool         lockable() noexcept    = 0;
-                virtual void*        getData() noexcept     = 0;
-            };
-
-            template <typename T>
-            class impl : public impl_base {
-              public:
-                impl(T* data, bool lock = true) noexcept : _lockable(lock), _data(data) {
+                impl_base(void* data, DeleteFn deleter, bool lock = false) noexcept : _lockable(lock), _data(data), _deleter(deleter) {
                     ;
                 }
 
+                void inc() noexcept {
+                    _ref++;
+                }
+
+                void dec() noexcept {
+                    _ref--;
+                }
+
+                void incWeak() noexcept {
+                    _weak++;
+                }
+
+                void decWeak() noexcept {
+                    _weak--;
+                }
+
+                unsigned int ref() noexcept {
+                    return _ref;
+                }
+
+                unsigned int wref() noexcept {
+                    return _weak;
+                }
+
+                void destroy() noexcept {
+                    _destroy();
+                }
+
+                bool destroying() noexcept {
+                    return _destroying;
+                }
+
+                bool lockable() noexcept {
+                    return _lockable;
+                }
+
+                bool dataNonNull() noexcept {
+                    return _data != nullptr;
+                }
+
+                void* getData() noexcept {
+                    return _data;
+                }
+
+                ~impl_base() {
+                    destroy();
+                }
+
+              private:
                 /* strong refcount */
                 unsigned int _ref = 0;
                 /* weak refcount */
                 unsigned int _weak = 0;
                 /* if this is lockable (shared) */
-                bool        _lockable = true;
+                bool  _lockable = true;
 
-                T*          _data = nullptr;
+                void* _data = nullptr;
 
-                friend void swap(impl*& a, impl*& b) {
-                    impl* tmp = a;
-                    a         = b;
-                    b         = tmp;
-                }
-
-                /* if the destructor was called, 
+                /* if the destructor was called,
                    creating shared_ptrs is no longer valid */
                 bool _destroying = false;
 
@@ -63,56 +90,7 @@ namespace Hyprutils {
                     _destroying = false;
                 }
 
-                std::default_delete<T> _deleter{};
-
-                //
-                virtual void inc() noexcept {
-                    _ref++;
-                }
-
-                virtual void dec() noexcept {
-                    _ref--;
-                }
-
-                virtual void incWeak() noexcept {
-                    _weak++;
-                }
-
-                virtual void decWeak() noexcept {
-                    _weak--;
-                }
-
-                virtual unsigned int ref() noexcept {
-                    return _ref;
-                }
-
-                virtual unsigned int wref() noexcept {
-                    return _weak;
-                }
-
-                virtual void destroy() noexcept {
-                    _destroy();
-                }
-
-                virtual bool destroying() noexcept {
-                    return _destroying;
-                }
-
-                virtual bool lockable() noexcept {
-                    return _lockable;
-                }
-
-                virtual bool dataNonNull() noexcept {
-                    return _data != nullptr;
-                }
-
-                virtual void* getData() noexcept {
-                    return _data;
-                }
-
-                virtual ~impl() {
-                    destroy();
-                }
+                DeleteFn _deleter = nullptr;
             };
         }
     }

--- a/include/hyprutils/memory/SharedPtr.hpp
+++ b/include/hyprutils/memory/SharedPtr.hpp
@@ -28,7 +28,7 @@ namespace Hyprutils {
 
             /* creates a new shared pointer managing a resource
                avoid calling. Could duplicate ownership. Prefer makeShared */
-            explicit CSharedPointer(T* object) noexcept : impl_(new Impl_::impl<T>(object)) {
+            explicit CSharedPointer(T* object) noexcept : impl_(new Impl_::impl_base(sc<void*>(object), _delete)) {
                 increment();
             }
 
@@ -140,6 +140,10 @@ namespace Hyprutils {
             Impl_::impl_base* impl_ = nullptr;
 
           private:
+            static void _delete(void* p) {
+                std::default_delete<T>{}(sc<T*>(p));
+            }
+
             /*
                 no-op if there is no impl_
                 may delete the stored object if ref == 0

--- a/include/hyprutils/memory/UniquePtr.hpp
+++ b/include/hyprutils/memory/UniquePtr.hpp
@@ -22,7 +22,7 @@ namespace Hyprutils {
 
             /* creates a new unique pointer managing a resource
                avoid calling. Could duplicate ownership. Prefer makeUnique */
-            explicit CUniquePointer(T* object) noexcept : impl_(new Impl_::impl<T>(object, false)) {
+            explicit CUniquePointer(T* object) noexcept : impl_(new Impl_::impl_base(sc<void*>(object), [](void* p) { std::default_delete<T>{}(sc<T*>(p)); }, false)) {
                 increment();
             }
 

--- a/tests/memory.cpp
+++ b/tests/memory.cpp
@@ -92,6 +92,38 @@ static int testAtomicImpl() {
         foo->bar      = foo;
     }
 
+    { // This tests destroying the data when storing the base class of a type
+        class ITest {
+          public:
+            size_t num = 0;
+            ITest() : num(1234) {};
+        };
+
+        class CA : public ITest {
+          public:
+            size_t num2 = 0;
+            CA() : ITest(), num2(4321) {};
+        };
+
+        class CB : public ITest {
+          public:
+            int num2 = 0;
+            CB() : ITest(), num2(-1) {};
+        };
+
+        ASP<ITest> genericAtomic = nullptr;
+        SP<ITest>  genericNormal = nullptr;
+        {
+            auto derivedAtomic = makeAtomicShared<CA>();
+            auto derivedNormal = makeShared<CA>();
+            genericAtomic      = derivedAtomic;
+            genericNormal      = derivedNormal;
+        }
+
+        EXPECT(!!genericAtomic, true);
+        EXPECT(!!genericNormal, true);
+    }
+
     return ret;
 }
 
@@ -149,6 +181,5 @@ int main(int argc, char** argv, char** envp) {
     EXPECT(*intPtr2, 10);
 
     EXPECT(testAtomicImpl(), 0);
-
     return ret;
 }


### PR DESCRIPTION
So @gulafaran noticed some UB with the current CAtomicSharedPointer implementation.

The problem is reproduced with the addition to the memory test here in the PR and `-fsanitize=undefined`.

The sanitizer reports this:
```
/usr/include/hyprutils/memory/Casts.hpp:7:16: runtime error: downcast of address 0x7b6cff916e10 which does not point to an object of type 'impl'
0x7b6cff916e10: note: object is of type 'Hyprutils::Memory::Atomic_::impl<Hyprgraphics::CImageResource>'
 00 00 00 00  f0 04 fb 86 c4 55 00 00  03 00 00 00 00 00 00 00  01 be be be be be be be  90 60 91 ff
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'Hyprutils::Memory::Atomic_::impl<Hyprgraphics::CImageResource>'
    #0 0x55c4833f7511 in Hyprutils::Memory::Atomic_::impl<Hyprgraphics::IAsyncResource>* Hyprutils::Memory::sc<Hyprutils::Memory::Atomic_::impl<Hyprgraphics::IAsyncResource>*, Hyprutils::Memory::Impl_::impl_base*&>(Hyprutils::Memory::Impl_::impl_base*&) /usr/include/hyprutils/memory/Casts.hpp:7
    #1 0x55c4833d9be6 in Hyprutils::Memory::CAtomicSharedPointer<Hyprgraphics::IAsyncResource>::reset() /usr/include/hyprutils/memory/Atomic.hpp:144
    #2 0x55c4833bfd58 in Hyprutils::Memory::CAtomicSharedPointer<Hyprgraphics::IAsyncResource>::~CAtomicSharedPointer() /usr/include/hyprutils/memory/Atomic.hpp:93
    #3 0x55c48335f139 in CHyprOpenGLImpl::requestBackgroundResource() /home/tom/Dev/Hyprland/src/render/OpenGL.cpp:2943
    #4 0x55c483360305 in CHyprOpenGLImpl::createBGTextureForMonitor(Hyprutils::Memory::CSharedPointer<CMonitor>) /home/tom/Dev/Hyprland/src/render/OpenGL.cpp:2959
    #5 0x55c483364571 in CHyprOpenGLImpl::clearWithTex() /home/tom/Dev/Hyprland/src/render/OpenGL.cpp:3063
    #6 0x55c483483279 in CHyprRenderer::renderBackground(Hyprutils::Memory::CSharedPointer<CMonitor>) /home/tom/Dev/Hyprland/src/render/Renderer.cpp:1014
    #7 0x55c48347c64c in CHyprRenderer::renderAllClientsForWorkspace(Hyprutils::Memory::CSharedPointer<CMonitor>, Hyprutils::Memory::CSharedPointer<CWorkspace>, std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > > const&, Hyprutils::Math::Vector2D const&, float const&) /home/tom/Dev/Hyprland/src/render/Renderer.cpp:908
    #8 0x55c48349a2c5 in CHyprRenderer::renderWorkspace(Hyprutils::Memory::CSharedPointer<CMonitor>, Hyprutils::Memory::CSharedPointer<CWorkspace>, std::chrono::time_point<std::chrono::_V2::steady_clock, std::chrono::duration<long, std::ratio<1l, 1000000000l> > > const&, Hyprutils::Math::CBox const&) /home/tom/Dev/Hyprland/src/render/Renderer.cpp:1634
    #9 0x55c48348ea75 in CHyprRenderer::renderMonitor(Hyprutils::Memory::CSharedPointer<CMonitor>, bool) /home/tom/Dev/Hyprland/src/render/Renderer.cpp:1338
```

The problem is that when storing an ASP of a base class, we then need to upcast to the atomic impl. That cast however is just wrong in this case.

Somehow the current implementation still manages to get the mutex despite this dubious cast.

While that is the problem that prompted for the solution in this PR, this also eliminates some virtual calls, which is nice.

The first draft and the idea came from tom and I finished it up.