### PR TITLE
src/cli/ArgumentParser.cpp: clang requires <algorithm>

### DIFF
--- a/src/cli/ArgumentParser.cpp
+++ b/src/cli/ArgumentParser.cpp
@@ -2,6 +2,7 @@
 
 #include <format>
 #include <vector>
+#include <algorithm>
 
 #include <hyprutils/string/String.hpp>
 #include <hyprutils/memory/Casts.hpp>


### PR DESCRIPTION
I am trying to build hypr* on OpenBSD-7.8/amd64. This uses clang-19.1.7.

hyprutils-0.10.3 has following error.

```
[ 20%] Building CXX object CMakeFiles/hyprutils.dir/src/cli/ArgumentParser.cpp.o
/home/uaa/hyprutils/src/cli/ArgumentParser.cpp:98:28: error: no member named 'find_if' in namespace 'std::ranges'
   98 |     auto it = std::ranges::find_if(m_values, [&sv](const auto& e) { return e.full == sv || e.abbrev == sv; });
      |               ~~~~~~~~~~~~~^
1 error generated.
```

to solve this, I had to add `#include <algorithm>` to ArgumentParser.cpp
