### PR TITLE
process: free argv allocations on execvp failure

### DIFF
--- a/src/os/Process.cpp
+++ b/src/os/Process.cpp
@@ -77,13 +77,13 @@ bool Hyprutils::OS::CProcess::runSync() {
             setenv(n.c_str(), v.c_str(), 1);
         }
 
-        if (execvp(m_impl->binary.c_str(), argsC.data()) == -1) {
-            for (auto ptr : argsC) {
-                if (ptr)
-                    free(ptr);
-            }
-            _exit(1);
+        execvp(m_impl->binary.c_str(), argsC.data());
+        for (auto ptr : argsC) {
+            if (ptr)
+                free(ptr);
         }
+        _exit(1);
+
     } else {
         // parent
         close(outPipe[1]);

--- a/src/os/Process.cpp
+++ b/src/os/Process.cpp
@@ -66,7 +66,7 @@ bool Hyprutils::OS::CProcess::runSync() {
         std::vector<char*> argsC;
         argsC.emplace_back(strdup(m_impl->binary.c_str()));
         for (auto& arg : m_impl->args) {
-            // TODO: does this leak? Can we just pipe c_str() as the strings won't be realloc'd?
+            // Arguments are duplicated for execvp; if execvp fails, they must be freed.
             argsC.emplace_back(strdup(arg.c_str()));
         }
 
@@ -77,8 +77,13 @@ bool Hyprutils::OS::CProcess::runSync() {
             setenv(n.c_str(), v.c_str(), 1);
         }
 
-        execvp(m_impl->binary.c_str(), argsC.data());
-        exit(1);
+        if (execvp(m_impl->binary.c_str(), argsC.data()) == -1) {
+            for (auto ptr : argsC) {
+                if (ptr)
+                    free(ptr);
+            }
+            _exit(1);
+        }
     } else {
         // parent
         close(outPipe[1]);


### PR DESCRIPTION
 What this PR does
Handles the failure case of execvp in CProcess::runSync.

 Problem
Arguments are allocated using strdup when building argv, but if execvp fails, those allocations are not freed before exiting.

 Solution
Free all duplicated argument strings before exiting when execvp returns an error. Also switch from exit to _exit to ensure correct behavior in the forked child process.

 Testing
-Built hyprutils successfully
-Verified normal execution (e.g., echo)
-Tested failure case with invalid binary (no crash, clean exit)
-Ran under valgrind:
 -No memory errors
 -No definite leaks
 -Only "still reachable" allocations in child process due to _exit, which is expected

 Notes
-No behavior change on successful execvp (process image is replaced)
-Keeps existing structure (allocations still occur in child as before)