### PR TITLE
process: handle execvp failure in runAsync and fix fd cleanup on fork error

### DIFF
--- a/src/os/Process.cpp
+++ b/src/os/Process.cpp
@@ -49,8 +49,8 @@ bool Hyprutils::OS::CProcess::runSync() {
     if (pid == -1) {
         close(outPipe[0]);
         close(outPipe[1]);
-        close(outPipe[0]);
-        close(outPipe[1]);
+        close(errPipe[0]);
+        close(errPipe[1]);
         return false;
     }
 
@@ -232,7 +232,14 @@ bool Hyprutils::OS::CProcess::runAsync() {
             }
 
             execvp(m_impl->binary.c_str(), argsC.data());
-            _exit(0);
+
+
+            for (auto ptr : argsC) {
+                if (ptr)
+                    free(ptr);
+            }
+
+            _exit(1);
         }
         close(socket[0]);
         if (write(socket[1], &grandchild, sizeof(grandchild)) != sizeof(grandchild)) {


### PR DESCRIPTION
While working on #106 around execvp handling, I noticed a similar pattern in runAsync and a bug in the fork error path in runSync. This PR updates runAsync to properly handle execvp failure by freeing duplicated argv entries and exiting with _exit(1) instead of incorrectly reporting success with _exit(0). It also fixes a copy-paste issue in the fork failure path where errPipe file descriptors were not being closed. I verified the changes using valgrind (ERROR SUMMARY: 0 errors from 0 contexts, no definitely/indirectly/possibly lost memory), with only “still reachable” allocations in child processes due to _exit, which is expected. There is no behavior change on successful execvp, and this aligns failure handling between runSync and runAsync.