### PR TITLE
fix: CBox::overlaps should not count adjacent boxes

### DIFF
--- a/src/math/Box.cpp
+++ b/src/math/Box.cpp
@@ -171,7 +171,7 @@ CBox Hyprutils::Math::CBox::intersection(const CBox& other) const {
 }
 
 bool Hyprutils::Math::CBox::overlaps(const CBox& other) const {
-    return (other.x + other.w >= x) && (x + w >= other.x) && (other.y + other.h >= y) && (y + h >= other.y);
+    return (other.x + other.w > x) && (x + w > other.x) && (other.y + other.h > y) && (y + h > other.y);
 }
 
 bool Hyprutils::Math::CBox::inside(const CBox& bound) const {


### PR DESCRIPTION
I noticed this when I was investigating why fullscreen windows in Hyprland were damaging adjacent monitors: https://github.com/hyprwm/Hyprland/blob/13d3695dd114f77da1258f041247306d485ed18e/src/render/Renderer.cpp#L2623

Before this change, CBox::overlaps would say that a 1x1 box at (0, 0) would overlap with a 1x1 box at (1, 1) when in fact no pixel is shared between the two.

I've reviewed the other callsites to overlaps in Hyprland and I'm pretty sure this change is better for them as well. I've also been running this change on a machine for a few days and haven't noticed any issues.

Intuitively, it doesn't make a lot of sense for e.g. two monitors' boxes to be considered overlapping if they're just adjacent, so I think the overlaps function itself should be changed instead of the callsites. However, if you disagree, I can also make the change directly to the renderer instead.