### PR TITLE
path: add function overloads with extension param

### DIFF
--- a/include/hyprutils/path/Path.hpp
+++ b/include/hyprutils/path/Path.hpp
@@ -13,11 +13,25 @@ namespace Hyprutils {
         */
         bool checkConfigExists(const std::string basePath, const std::string programName);
 
+        /** Check whether a config in the form basePath/hypr/programName.{extension} exists.
+            @param basePath the path where the config will be searched
+            @param programName name of the program (and config file) to search for
+            @param extension extension of the config file
+        */
+        bool checkConfigExists(const std::string basePath, const std::string programName, const std::string extension);
+
         /** Constructs a full config path given the basePath and programName.
             @param basePath the path where the config hypr/programName.conf is located
             @param programName name of the program (and config file)
         */
         std::string fullConfigPath(const std::string basePath, const std::string programName);
+
+        /** Constructs a full config path given the basePath and programName.
+            @param basePath the path where the config hypr/programName.conf is located
+            @param programName name of the program (and config file)
+            @param extension extension of the config file
+        */
+        std::string fullConfigPath(const std::string basePath, const std::string programName, const std::string extension);
 
         /** Retrieves the absolute path of the $HOME env variable.
         */
@@ -39,6 +53,15 @@ namespace Hyprutils {
 
         using T = std::optional<std::string>;
         std::pair<T, T> findConfig(const std::string programName);
+
+        /** Searches for a config according to the XDG Base Directory specification.
+            Returns a pair of the full path to a config and the base path.
+            Returns std::nullopt in case of a non-existent value.
+            @param programName name of the program (and config file)
+            @param extension extension of the config file
+        */
+
+        std::pair<T, T> findConfig(const std::string programName, const std::string extension);
 
         /** Resolves a path, expanding ~, ., and .. components relative to the given base.
             If base is empty, the current working directory is used as the base for relative paths.

--- a/src/path/Path.cpp
+++ b/src/path/Path.cpp
@@ -10,8 +10,16 @@ namespace Hyprutils::Path {
         return basePath + "/hypr/" + programName + ".conf";
     }
 
+    std::string fullConfigPath(std::string basePath, std::string programName, std::string extension) {
+        return basePath + "/hypr/" + programName + "." + extension;
+    }
+
     bool checkConfigExists(std::string basePath, std::string programName) {
         return std::filesystem::exists(fullConfigPath(basePath, programName));
+    }
+
+    bool checkConfigExists(std::string basePath, std::string programName, std::string extension) {
+        return std::filesystem::exists(fullConfigPath(basePath, programName, extension));
     }
 
     std::optional<std::string> getHome() {
@@ -45,32 +53,36 @@ namespace Hyprutils::Path {
 
     using T = std::optional<std::string>;
     std::pair<T, T> findConfig(std::string programName) {
+        return findConfig(programName, "conf");
+    }
+
+    std::pair<T, T> findConfig(std::string programName, std::string extension) {
         bool              xdgConfigHomeExists = false;
         static const auto xdgConfigHome       = getXdgConfigHome();
         if (xdgConfigHome.has_value()) {
             xdgConfigHomeExists = true;
-            if (checkConfigExists(xdgConfigHome.value(), programName))
-                return std::make_pair(fullConfigPath(xdgConfigHome.value(), programName), xdgConfigHome);
+            if (checkConfigExists(xdgConfigHome.value(), programName, extension))
+                return std::make_pair(fullConfigPath(xdgConfigHome.value(), programName, extension), xdgConfigHome);
         }
 
         bool              homeExists = false;
         static const auto home       = getHome();
         if (home.has_value()) {
             homeExists = true;
-            if (checkConfigExists(home.value(), programName))
-                return std::make_pair(fullConfigPath(home.value(), programName), home);
+            if (checkConfigExists(home.value(), programName, extension))
+                return std::make_pair(fullConfigPath(home.value(), programName, extension), home);
         }
 
         static const auto xdgConfigDirs = getXdgConfigDirs();
         if (xdgConfigDirs.has_value()) {
             for (auto& dir : xdgConfigDirs.value()) {
-                if (checkConfigExists(dir, programName))
-                    return std::make_pair(fullConfigPath(dir, programName), std::nullopt);
+                if (checkConfigExists(dir, programName, extension))
+                    return std::make_pair(fullConfigPath(dir, programName, extension), std::nullopt);
             }
         }
 
-        if (checkConfigExists("/etc/xdg", programName))
-            return std::make_pair(fullConfigPath("/etc/xdg", programName), std::nullopt);
+        if (checkConfigExists("/etc/xdg", programName, extension))
+            return std::make_pair(fullConfigPath("/etc/xdg", programName, extension), std::nullopt);
 
         if (xdgConfigHomeExists)
             return std::make_pair(std::nullopt, xdgConfigHome);


### PR DESCRIPTION
Adds function overloads for Path namespace. Allows specifying an extension other than the default "conf".
