### PR TITLE
animations: advance springs by elapsed time

### DIFF
--- a/src/animation/AnimatedVariable.cpp
+++ b/src/animation/AnimatedVariable.cpp
@@ -123,10 +123,10 @@ CBaseAnimatedVariable::SCurveStepResult CBaseAnimatedVariable::getCurveStep() {
         return {.value = 1.F, .finished = true};
 
     const auto NOW = std::chrono::steady_clock::now();
-    float      dt  = Details::springDeltaTime(NOW, springLastStep);
+    const auto DT  = NOW - springLastStep;
     springLastStep = NOW;
 
-    Details::advanceSpring(m_fSpringValue, m_fSpringVelocity, *SPRING, dt);
+    Details::advanceSpring(m_fSpringValue, m_fSpringVelocity, *SPRING, DT);
 
     const bool FINISHED = std::abs(1.F - m_fSpringValue) <= SPRING->valueEpsilon && std::abs(m_fSpringVelocity) <= SPRING->velocityEpsilon;
     if (FINISHED) {

--- a/src/animation/AnimatedVariable.cpp
+++ b/src/animation/AnimatedVariable.cpp
@@ -15,6 +15,54 @@ static constexpr std::string_view SPRINGPREFIX      = "spring:";
 #define SP CSharedPointer
 #define WP CWeakPointer
 
+static void advanceSpring(float& value, float& velocity, const SSpringCurve& spring, float dt) {
+    if (dt <= 0.F)
+        return;
+
+    const float MASS      = std::max(spring.mass, 0.0001F);
+    const float STIFFNESS = std::max(spring.stiffness, 0.0001F);
+    const float DAMPING   = std::max(spring.damping, 0.F);
+
+    const float DISPLACEMENT = value - 1.F;
+    const float OMEGA0       = std::sqrt(STIFFNESS / MASS);
+    const float GAMMA        = DAMPING / (2.F * MASS);
+
+    if (GAMMA < OMEGA0) {
+        const float OMEGAD = std::sqrt((OMEGA0 * OMEGA0) - (GAMMA * GAMMA));
+        const float EXP    = std::exp(-GAMMA * dt);
+        const float SIN    = std::sin(OMEGAD * dt);
+        const float COS    = std::cos(OMEGAD * dt);
+
+        const float NEW_DISPLACEMENT = EXP * ((DISPLACEMENT * COS) + (((velocity + (GAMMA * DISPLACEMENT)) / OMEGAD) * SIN));
+        const float NEW_VELOCITY     = EXP * ((velocity * COS) - (((GAMMA * velocity) + (OMEGA0 * OMEGA0 * DISPLACEMENT)) / OMEGAD) * SIN);
+
+        value    = 1.F + NEW_DISPLACEMENT;
+        velocity = NEW_VELOCITY;
+        return;
+    }
+
+    const float CRITICAL_EPSILON = std::max(OMEGA0, 1.F) * 0.0001F;
+    if (std::abs(GAMMA - OMEGA0) <= CRITICAL_EPSILON) {
+        const float EXP = std::exp(-GAMMA * dt);
+        const float B   = velocity + (GAMMA * DISPLACEMENT);
+
+        value    = 1.F + (EXP * (DISPLACEMENT + (B * dt)));
+        velocity = EXP * (velocity - (GAMMA * B * dt));
+        return;
+    }
+
+    const float ROOT = std::sqrt((GAMMA * GAMMA) - (OMEGA0 * OMEGA0));
+    const float R1   = -GAMMA + ROOT;
+    const float R2   = -GAMMA - ROOT;
+    const float A    = (velocity - (R2 * DISPLACEMENT)) / (R1 - R2);
+    const float B    = DISPLACEMENT - A;
+    const float E1   = std::exp(R1 * dt);
+    const float E2   = std::exp(R2 * dt);
+
+    value    = 1.F + (A * E1) + (B * E2);
+    velocity = (A * R1 * E1) + (B * R2 * E2);
+}
+
 void CBaseAnimatedVariable::create(CAnimationManager* pManager, int typeInfo, SP<CBaseAnimatedVariable> pSelf) {
     m_Type  = typeInfo;
     m_pSelf = std::move(pSelf);
@@ -129,22 +177,9 @@ CBaseAnimatedVariable::SCurveStepResult CBaseAnimatedVariable::getCurveStep() {
     if (dt <= 0.F)
         dt = MINDELTA;
     else
-        dt = std::clamp(dt, MINDELTA, 0.05F);
+        dt = std::max(dt, MINDELTA);
 
-    if (dt > 0.F) {
-        constexpr const float FIXEDSTEP = 1.F / 240.F;
-        const int             SUBSTEPS  = std::clamp(static_cast<int>(std::ceil(dt / FIXEDSTEP)), 1, 16);
-        const float           STEPTIME  = dt / SUBSTEPS;
-        const float           MASS      = std::max(SPRING->mass, 0.0001f);
-
-        for (int i = 0; i < SUBSTEPS; ++i) {
-            const float displacement = m_fSpringValue - 1.f;
-            const float acceleration = ((-SPRING->stiffness * displacement) - (SPRING->damping * m_fSpringVelocity)) / MASS;
-
-            m_fSpringVelocity += acceleration * STEPTIME;
-            m_fSpringValue += m_fSpringVelocity * STEPTIME;
-        }
-    }
+    advanceSpring(m_fSpringValue, m_fSpringVelocity, *SPRING, dt);
 
     const bool FINISHED = std::abs(1.F - m_fSpringValue) <= SPRING->valueEpsilon && std::abs(m_fSpringVelocity) <= SPRING->velocityEpsilon;
     if (FINISHED) {

--- a/src/animation/AnimatedVariable.cpp
+++ b/src/animation/AnimatedVariable.cpp
@@ -1,6 +1,7 @@
 #include <hyprutils/animation/AnimatedVariable.hpp>
 #include <hyprutils/animation/AnimationManager.hpp>
 #include <hyprutils/memory/WeakPtr.hpp>
+#include "animation/Spring.hpp"
 
 #include <algorithm>
 #include <cmath>
@@ -14,54 +15,6 @@ static constexpr std::string_view SPRINGPREFIX      = "spring:";
 
 #define SP CSharedPointer
 #define WP CWeakPointer
-
-static void advanceSpring(float& value, float& velocity, const SSpringCurve& spring, float dt) {
-    if (dt <= 0.F)
-        return;
-
-    const float MASS      = std::max(spring.mass, 0.0001F);
-    const float STIFFNESS = std::max(spring.stiffness, 0.0001F);
-    const float DAMPING   = std::max(spring.damping, 0.F);
-
-    const float DISPLACEMENT = value - 1.F;
-    const float OMEGA0       = std::sqrt(STIFFNESS / MASS);
-    const float GAMMA        = DAMPING / (2.F * MASS);
-
-    if (GAMMA < OMEGA0) {
-        const float OMEGAD = std::sqrt((OMEGA0 * OMEGA0) - (GAMMA * GAMMA));
-        const float EXP    = std::exp(-GAMMA * dt);
-        const float SIN    = std::sin(OMEGAD * dt);
-        const float COS    = std::cos(OMEGAD * dt);
-
-        const float NEW_DISPLACEMENT = EXP * ((DISPLACEMENT * COS) + (((velocity + (GAMMA * DISPLACEMENT)) / OMEGAD) * SIN));
-        const float NEW_VELOCITY     = EXP * ((velocity * COS) - (((GAMMA * velocity) + (OMEGA0 * OMEGA0 * DISPLACEMENT)) / OMEGAD) * SIN);
-
-        value    = 1.F + NEW_DISPLACEMENT;
-        velocity = NEW_VELOCITY;
-        return;
-    }
-
-    const float CRITICAL_EPSILON = std::max(OMEGA0, 1.F) * 0.0001F;
-    if (std::abs(GAMMA - OMEGA0) <= CRITICAL_EPSILON) {
-        const float EXP = std::exp(-GAMMA * dt);
-        const float B   = velocity + (GAMMA * DISPLACEMENT);
-
-        value    = 1.F + (EXP * (DISPLACEMENT + (B * dt)));
-        velocity = EXP * (velocity - (GAMMA * B * dt));
-        return;
-    }
-
-    const float ROOT = std::sqrt((GAMMA * GAMMA) - (OMEGA0 * OMEGA0));
-    const float R1   = -GAMMA + ROOT;
-    const float R2   = -GAMMA - ROOT;
-    const float A    = (velocity - (R2 * DISPLACEMENT)) / (R1 - R2);
-    const float B    = DISPLACEMENT - A;
-    const float E1   = std::exp(R1 * dt);
-    const float E2   = std::exp(R2 * dt);
-
-    value    = 1.F + (A * E1) + (B * E2);
-    velocity = (A * R1 * E1) + (B * R2 * E2);
-}
 
 void CBaseAnimatedVariable::create(CAnimationManager* pManager, int typeInfo, SP<CBaseAnimatedVariable> pSelf) {
     m_Type  = typeInfo;
@@ -170,16 +123,10 @@ CBaseAnimatedVariable::SCurveStepResult CBaseAnimatedVariable::getCurveStep() {
         return {.value = 1.F, .finished = true};
 
     const auto NOW = std::chrono::steady_clock::now();
-    float      dt  = std::chrono::duration<float>(NOW - springLastStep).count();
+    float      dt  = Details::springDeltaTime(NOW, springLastStep);
     springLastStep = NOW;
 
-    constexpr float MINDELTA = 1.F / 240.F;
-    if (dt <= 0.F)
-        dt = MINDELTA;
-    else
-        dt = std::max(dt, MINDELTA);
-
-    advanceSpring(m_fSpringValue, m_fSpringVelocity, *SPRING, dt);
+    Details::advanceSpring(m_fSpringValue, m_fSpringVelocity, *SPRING, dt);
 
     const bool FINISHED = std::abs(1.F - m_fSpringValue) <= SPRING->valueEpsilon && std::abs(m_fSpringVelocity) <= SPRING->velocityEpsilon;
     if (FINISHED) {

--- a/src/animation/Spring.cpp
+++ b/src/animation/Spring.cpp
@@ -1,0 +1,55 @@
+#include "animation/Spring.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+using namespace Hyprutils::Animation;
+
+void Details::advanceSpring(float& value, float& velocity, const SSpringCurve& spring, std::chrono::duration<float> elapsed) {
+    const float DT = std::max(elapsed.count(), 0.F);
+    if (DT <= 0.F)
+        return;
+
+    const float MASS      = std::max(spring.mass, 0.0001F);
+    const float STIFFNESS = std::max(spring.stiffness, 0.0001F);
+    const float DAMPING   = std::max(spring.damping, 0.F);
+
+    const float DISPLACEMENT = value - 1.F;
+    const float OMEGA0       = std::sqrt(STIFFNESS / MASS);
+    const float GAMMA        = DAMPING / (2.F * MASS);
+
+    if (GAMMA < OMEGA0) {
+        const float OMEGAD = std::sqrt((OMEGA0 * OMEGA0) - (GAMMA * GAMMA));
+        const float EXP    = std::exp(-GAMMA * DT);
+        const float SIN    = std::sin(OMEGAD * DT);
+        const float COS    = std::cos(OMEGAD * DT);
+
+        const float NEW_DISPLACEMENT = EXP * ((DISPLACEMENT * COS) + (((velocity + (GAMMA * DISPLACEMENT)) / OMEGAD) * SIN));
+        const float NEW_VELOCITY     = EXP * ((velocity * COS) - (((GAMMA * velocity) + (OMEGA0 * OMEGA0 * DISPLACEMENT)) / OMEGAD) * SIN);
+
+        value    = 1.F + NEW_DISPLACEMENT;
+        velocity = NEW_VELOCITY;
+        return;
+    }
+
+    const float CRITICAL_EPSILON = std::max(OMEGA0, 1.F) * 0.0001F;
+    if (std::abs(GAMMA - OMEGA0) <= CRITICAL_EPSILON) {
+        const float EXP = std::exp(-GAMMA * DT);
+        const float B   = velocity + (GAMMA * DISPLACEMENT);
+
+        value    = 1.F + (EXP * (DISPLACEMENT + (B * DT)));
+        velocity = EXP * (velocity - (GAMMA * B * DT));
+        return;
+    }
+
+    const float ROOT = std::sqrt((GAMMA * GAMMA) - (OMEGA0 * OMEGA0));
+    const float R1   = -GAMMA + ROOT;
+    const float R2   = -GAMMA - ROOT;
+    const float A    = (velocity - (R2 * DISPLACEMENT)) / (R1 - R2);
+    const float B    = DISPLACEMENT - A;
+    const float E1   = std::exp(R1 * DT);
+    const float E2   = std::exp(R2 * DT);
+
+    value    = 1.F + (A * E1) + (B * E2);
+    velocity = (A * R1 * E1) + (B * R2 * E2);
+}

--- a/src/animation/Spring.hpp
+++ b/src/animation/Spring.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <hyprutils/animation/AnimationManager.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+
+namespace Hyprutils::Animation::Details {
+    inline float springDeltaTime(std::chrono::steady_clock::time_point now, std::chrono::steady_clock::time_point last) {
+        return std::max(std::chrono::duration<float>(now - last).count(), 0.F);
+    }
+
+    inline void advanceSpring(float& value, float& velocity, const SSpringCurve& spring, float dt) {
+        if (dt <= 0.F)
+            return;
+
+        const float MASS      = std::max(spring.mass, 0.0001F);
+        const float STIFFNESS = std::max(spring.stiffness, 0.0001F);
+        const float DAMPING   = std::max(spring.damping, 0.F);
+
+        const float DISPLACEMENT = value - 1.F;
+        const float OMEGA0       = std::sqrt(STIFFNESS / MASS);
+        const float GAMMA        = DAMPING / (2.F * MASS);
+
+        if (GAMMA < OMEGA0) {
+            const float OMEGAD = std::sqrt((OMEGA0 * OMEGA0) - (GAMMA * GAMMA));
+            const float EXP    = std::exp(-GAMMA * dt);
+            const float SIN    = std::sin(OMEGAD * dt);
+            const float COS    = std::cos(OMEGAD * dt);
+
+            const float NEW_DISPLACEMENT = EXP * ((DISPLACEMENT * COS) + (((velocity + (GAMMA * DISPLACEMENT)) / OMEGAD) * SIN));
+            const float NEW_VELOCITY     = EXP * ((velocity * COS) - (((GAMMA * velocity) + (OMEGA0 * OMEGA0 * DISPLACEMENT)) / OMEGAD) * SIN);
+
+            value    = 1.F + NEW_DISPLACEMENT;
+            velocity = NEW_VELOCITY;
+            return;
+        }
+
+        const float CRITICAL_EPSILON = std::max(OMEGA0, 1.F) * 0.0001F;
+        if (std::abs(GAMMA - OMEGA0) <= CRITICAL_EPSILON) {
+            const float EXP = std::exp(-GAMMA * dt);
+            const float B   = velocity + (GAMMA * DISPLACEMENT);
+
+            value    = 1.F + (EXP * (DISPLACEMENT + (B * dt)));
+            velocity = EXP * (velocity - (GAMMA * B * dt));
+            return;
+        }
+
+        const float ROOT = std::sqrt((GAMMA * GAMMA) - (OMEGA0 * OMEGA0));
+        const float R1   = -GAMMA + ROOT;
+        const float R2   = -GAMMA - ROOT;
+        const float A    = (velocity - (R2 * DISPLACEMENT)) / (R1 - R2);
+        const float B    = DISPLACEMENT - A;
+        const float E1   = std::exp(R1 * dt);
+        const float E2   = std::exp(R2 * dt);
+
+        value    = 1.F + (A * E1) + (B * E2);
+        velocity = (A * R1 * E1) + (B * R2 * E2);
+    }
+}

--- a/src/animation/Spring.hpp
+++ b/src/animation/Spring.hpp
@@ -2,60 +2,8 @@
 
 #include <hyprutils/animation/AnimationManager.hpp>
 
-#include <algorithm>
 #include <chrono>
-#include <cmath>
 
 namespace Hyprutils::Animation::Details {
-    inline float springDeltaTime(std::chrono::steady_clock::time_point now, std::chrono::steady_clock::time_point last) {
-        return std::max(std::chrono::duration<float>(now - last).count(), 0.F);
-    }
-
-    inline void advanceSpring(float& value, float& velocity, const SSpringCurve& spring, float dt) {
-        if (dt <= 0.F)
-            return;
-
-        const float MASS      = std::max(spring.mass, 0.0001F);
-        const float STIFFNESS = std::max(spring.stiffness, 0.0001F);
-        const float DAMPING   = std::max(spring.damping, 0.F);
-
-        const float DISPLACEMENT = value - 1.F;
-        const float OMEGA0       = std::sqrt(STIFFNESS / MASS);
-        const float GAMMA        = DAMPING / (2.F * MASS);
-
-        if (GAMMA < OMEGA0) {
-            const float OMEGAD = std::sqrt((OMEGA0 * OMEGA0) - (GAMMA * GAMMA));
-            const float EXP    = std::exp(-GAMMA * dt);
-            const float SIN    = std::sin(OMEGAD * dt);
-            const float COS    = std::cos(OMEGAD * dt);
-
-            const float NEW_DISPLACEMENT = EXP * ((DISPLACEMENT * COS) + (((velocity + (GAMMA * DISPLACEMENT)) / OMEGAD) * SIN));
-            const float NEW_VELOCITY     = EXP * ((velocity * COS) - (((GAMMA * velocity) + (OMEGA0 * OMEGA0 * DISPLACEMENT)) / OMEGAD) * SIN);
-
-            value    = 1.F + NEW_DISPLACEMENT;
-            velocity = NEW_VELOCITY;
-            return;
-        }
-
-        const float CRITICAL_EPSILON = std::max(OMEGA0, 1.F) * 0.0001F;
-        if (std::abs(GAMMA - OMEGA0) <= CRITICAL_EPSILON) {
-            const float EXP = std::exp(-GAMMA * dt);
-            const float B   = velocity + (GAMMA * DISPLACEMENT);
-
-            value    = 1.F + (EXP * (DISPLACEMENT + (B * dt)));
-            velocity = EXP * (velocity - (GAMMA * B * dt));
-            return;
-        }
-
-        const float ROOT = std::sqrt((GAMMA * GAMMA) - (OMEGA0 * OMEGA0));
-        const float R1   = -GAMMA + ROOT;
-        const float R2   = -GAMMA - ROOT;
-        const float A    = (velocity - (R2 * DISPLACEMENT)) / (R1 - R2);
-        const float B    = DISPLACEMENT - A;
-        const float E1   = std::exp(R1 * dt);
-        const float E2   = std::exp(R2 * dt);
-
-        value    = 1.F + (A * E1) + (B * E2);
-        velocity = (A * R1 * E1) + (B * R2 * E2);
-    }
+    void advanceSpring(float& value, float& velocity, const SSpringCurve& spring, std::chrono::duration<float> elapsed);
 }

--- a/tests/animation/Animation.cpp
+++ b/tests/animation/Animation.cpp
@@ -394,12 +394,30 @@ TEST(Animation, animation) {
     EXPECT_EQ(pAnimationManager.get(), nullptr);
 }
 
-TEST(Animation, springDeltaUsesElapsedTime) {
-    const auto START = std::chrono::steady_clock::time_point{} + std::chrono::seconds(1);
+TEST(Animation, springAdvanceUsesElapsedTime) {
+    const SSpringCurve SPRING = {
+        .stiffness       = 100.f,
+        .damping         = 20.f,
+        .mass            = 1.f,
+        .valueEpsilon    = 0.001f,
+        .velocityEpsilon = 0.001f,
+    };
 
-    EXPECT_NEAR(Details::springDeltaTime(START + std::chrono::milliseconds(1), START), 0.001F, 0.000001F);
-    EXPECT_NEAR(Details::springDeltaTime(START + std::chrono::milliseconds(120), START), 0.120F, 0.000001F);
-    EXPECT_EQ(Details::springDeltaTime(START, START + std::chrono::milliseconds(1)), 0.F);
+    float oneMsValue        = 0.F;
+    float oneMsVelocity     = 0.F;
+    float hundredMsValue    = 0.F;
+    float hundredMsVelocity = 0.F;
+    float negativeValue     = 0.F;
+    float negativeVelocity  = 0.F;
+
+    Details::advanceSpring(oneMsValue, oneMsVelocity, SPRING, std::chrono::milliseconds(1));
+    Details::advanceSpring(hundredMsValue, hundredMsVelocity, SPRING, std::chrono::milliseconds(120));
+    Details::advanceSpring(negativeValue, negativeVelocity, SPRING, std::chrono::milliseconds(-1));
+
+    EXPECT_GT(oneMsValue, 0.F);
+    EXPECT_GT(hundredMsValue, oneMsValue);
+    EXPECT_EQ(negativeValue, 0.F);
+    EXPECT_EQ(negativeVelocity, 0.F);
 }
 
 TEST(Animation, springAdvancesAcrossLateTicks) {
@@ -416,8 +434,8 @@ TEST(Animation, springAdvancesAcrossLateTicks) {
     float cappedValue    = 0.F;
     float cappedVelocity = 0.F;
 
-    Details::advanceSpring(lateValue, lateVelocity, SPRING, 0.120F);
-    Details::advanceSpring(cappedValue, cappedVelocity, SPRING, 0.050F);
+    Details::advanceSpring(lateValue, lateVelocity, SPRING, std::chrono::milliseconds(120));
+    Details::advanceSpring(cappedValue, cappedVelocity, SPRING, std::chrono::milliseconds(50));
 
     EXPECT_GT(lateValue, cappedValue);
     EXPECT_GT(lateValue, 0.25F);
@@ -438,9 +456,9 @@ TEST(Animation, springDoesNotAdvanceFasterThanElapsedTime) {
     float singleVelocity   = 0.F;
 
     for (size_t i = 0; i < 132; ++i)
-        Details::advanceSpring(repeatedValue, repeatedVelocity, SPRING, 0.001F);
+        Details::advanceSpring(repeatedValue, repeatedVelocity, SPRING, std::chrono::milliseconds(1));
 
-    Details::advanceSpring(singleValue, singleVelocity, SPRING, 0.132F);
+    Details::advanceSpring(singleValue, singleVelocity, SPRING, std::chrono::milliseconds(132));
 
     EXPECT_NEAR(repeatedValue, singleValue, 0.0001F);
     EXPECT_LT(repeatedValue, 0.5F);

--- a/tests/animation/Animation.cpp
+++ b/tests/animation/Animation.cpp
@@ -7,6 +7,9 @@
 #include <hyprutils/memory/WeakPtr.hpp>
 #include <hyprutils/memory/UniquePtr.hpp>
 
+#include <chrono>
+#include <thread>
+
 #define SP CSharedPointer
 #define WP CWeakPointer
 #define UP CUniquePointer
@@ -436,4 +439,31 @@ TEST(Animation, springRetargetPreservesVelocity) {
 
     EXPECT_EQ(av->value(), 0);
     EXPECT_EQ(fromRest->value(), 0);
+}
+
+TEST(Animation, springAdvancesAcrossLateTicks) {
+    config();
+
+    pAnimationManager->addSpringWithName("late",
+                                         {
+                                             .stiffness       = 100.f,
+                                             .damping         = 20.f,
+                                             .mass            = 1.f,
+                                             .valueEpsilon    = 0.001f,
+                                             .velocityEpsilon = 0.001f,
+                                         });
+
+    animationTree.createNode("late_tick_global");
+    animationTree.createNode("late_tick", "late_tick_global");
+    animationTree.setConfigForNode("late_tick_global", 1, 1.f, "spring:late");
+
+    PANIMVAR<int> av;
+    pAnimationManager->createAnimation(0, av, "late_tick");
+
+    *av = 100;
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(120));
+    pAnimationManager->tick();
+
+    EXPECT_GT(av->value(), 25);
 }

--- a/tests/animation/Animation.cpp
+++ b/tests/animation/Animation.cpp
@@ -6,9 +6,9 @@
 #include <hyprutils/animation/AnimatedVariable.hpp>
 #include <hyprutils/memory/WeakPtr.hpp>
 #include <hyprutils/memory/UniquePtr.hpp>
+#include "animation/Spring.hpp"
 
 #include <chrono>
-#include <thread>
 
 #define SP CSharedPointer
 #define WP CWeakPointer
@@ -394,76 +394,54 @@ TEST(Animation, animation) {
     EXPECT_EQ(pAnimationManager.get(), nullptr);
 }
 
-TEST(Animation, springRetargetPreservesVelocity) {
-    config();
+TEST(Animation, springDeltaUsesElapsedTime) {
+    const auto START = std::chrono::steady_clock::time_point{} + std::chrono::seconds(1);
 
-    pAnimationManager->addSpringWithName("momentum",
-                                         {
-                                             .stiffness       = 120.f,
-                                             .damping         = 8.f,
-                                             .mass            = 1.f,
-                                             .valueEpsilon    = 0.001f,
-                                             .velocityEpsilon = 0.001f,
-                                         });
-
-    animationTree.createNode("spring_global");
-    animationTree.createNode("spring_velocity", "spring_global");
-    animationTree.setConfigForNode("spring_global", 1, 1.f, "spring:momentum");
-
-    PANIMVAR<int> av;
-    pAnimationManager->createAnimation(0, av, "spring_velocity");
-
-    *av = 100;
-
-    int ticks = 0;
-    while (av->value() < 40 && ticks++ < 300) {
-        pAnimationManager->tick();
-    }
-
-    const auto RETARGETPOINT = av->value();
-    EXPECT_GT(RETARGETPOINT, 20);
-
-    PANIMVAR<int> fromRest;
-    pAnimationManager->createAnimation(RETARGETPOINT, fromRest, "spring_velocity");
-
-    *av       = 0;
-    *fromRest = 0;
-    EXPECT_EQ(av->value(), RETARGETPOINT);
-
-    pAnimationManager->tick();
-    EXPECT_GT(av->value(), fromRest->value());
-
-    while (pAnimationManager->shouldTickForNext() && ticks++ < 2000) {
-        pAnimationManager->tick();
-    }
-
-    EXPECT_EQ(av->value(), 0);
-    EXPECT_EQ(fromRest->value(), 0);
+    EXPECT_NEAR(Details::springDeltaTime(START + std::chrono::milliseconds(1), START), 0.001F, 0.000001F);
+    EXPECT_NEAR(Details::springDeltaTime(START + std::chrono::milliseconds(120), START), 0.120F, 0.000001F);
+    EXPECT_EQ(Details::springDeltaTime(START, START + std::chrono::milliseconds(1)), 0.F);
 }
 
 TEST(Animation, springAdvancesAcrossLateTicks) {
-    config();
+    const SSpringCurve SPRING = {
+        .stiffness       = 100.f,
+        .damping         = 20.f,
+        .mass            = 1.f,
+        .valueEpsilon    = 0.001f,
+        .velocityEpsilon = 0.001f,
+    };
 
-    pAnimationManager->addSpringWithName("late",
-                                         {
-                                             .stiffness       = 100.f,
-                                             .damping         = 20.f,
-                                             .mass            = 1.f,
-                                             .valueEpsilon    = 0.001f,
-                                             .velocityEpsilon = 0.001f,
-                                         });
+    float lateValue      = 0.F;
+    float lateVelocity   = 0.F;
+    float cappedValue    = 0.F;
+    float cappedVelocity = 0.F;
 
-    animationTree.createNode("late_tick_global");
-    animationTree.createNode("late_tick", "late_tick_global");
-    animationTree.setConfigForNode("late_tick_global", 1, 1.f, "spring:late");
+    Details::advanceSpring(lateValue, lateVelocity, SPRING, 0.120F);
+    Details::advanceSpring(cappedValue, cappedVelocity, SPRING, 0.050F);
 
-    PANIMVAR<int> av;
-    pAnimationManager->createAnimation(0, av, "late_tick");
+    EXPECT_GT(lateValue, cappedValue);
+    EXPECT_GT(lateValue, 0.25F);
+}
 
-    *av = 100;
+TEST(Animation, springDoesNotAdvanceFasterThanElapsedTime) {
+    const SSpringCurve SPRING = {
+        .stiffness       = 38.f,
+        .damping         = 8.f,
+        .mass            = 2.4f,
+        .valueEpsilon    = 0.001f,
+        .velocityEpsilon = 0.001f,
+    };
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(120));
-    pAnimationManager->tick();
+    float repeatedValue    = 0.F;
+    float repeatedVelocity = 0.F;
+    float singleValue      = 0.F;
+    float singleVelocity   = 0.F;
 
-    EXPECT_GT(av->value(), 25);
+    for (size_t i = 0; i < 132; ++i)
+        Details::advanceSpring(repeatedValue, repeatedVelocity, SPRING, 0.001F);
+
+    Details::advanceSpring(singleValue, singleVelocity, SPRING, 0.132F);
+
+    EXPECT_NEAR(repeatedValue, singleValue, 0.0001F);
+    EXPECT_LT(repeatedValue, 0.5F);
 }


### PR DESCRIPTION
## What changed

This PR fixes two separate spring timing bugs that can make Hyprland spring animations appear load-dependent:

1. Replaces the fixed-substep Euler spring integration with a closed-form damped spring step for underdamped, critically damped, and overdamped springs.
2. Removes the `1 / 240s` minimum spring timestep floor now that the spring step is analytic.

Spring animations now advance according to the actual elapsed wall time between ticks, without either discarding long delays or over-advancing short delays.

## Why

Hyprland discussions https://github.com/hyprwm/Hyprland/discussions/14440 and https://github.com/hyprwm/Hyprland/discussions/14571 point to spring animations appearing to slow down under CPU load.

The original version of this PR fixed one real bug: late ticks were capped to `0.05s`. If the compositor missed a spring tick by more than 50ms, the extra elapsed time was discarded, so spring progress lagged behind wall time. That explained one way CPU load could make springs appear slower.

After testing that change in a real Hyprland session, the issue still reproduced. The remaining problem was the opposite side of the same timing path: spring ticks were floored to `1 / 240s`. Hyprland can schedule animation ticks around every 1ms, so an idle compositor could simulate about 4.17ms of spring time per 1ms real tick. Under CPU load, ticks happen less frequently, so the spring falls back toward real elapsed time. The visible result is that animations seem to slow down under load, but the real bug is that they were running too fast when the compositor was idle.

With both the maximum-delta clamp and minimum-delta floor removed, spring progress is tied to elapsed wall time in both directions. Render cost should now result in fewer/coarser frames rather than changing animation pace.

## User impact

This is a behavior change for existing spring configs. Any spring settings that were tuned against the old idle behavior were likely tuned around springs running faster than wall time. After this fix, those same settings can feel significantly slower even though they are now time-correct.

Users with custom spring curves should expect to retune their animation settings, typically by increasing stiffness, reducing mass, and/or adjusting damping to recover a similar perceived speed without relying on tick-rate-dependent over-advancement.

## Tests

- `nix build .#hyprutils-with-tests -L`
- `nix build .#hyprutils -L`

Added regression coverage for both timing bugs:

- elapsed spring time uses the raw elapsed duration, with no `1 / 240s` floor and no `0.05s` cap;
- a delayed spring step advances farther than the old capped 50ms step;
- repeated high-frequency spring steps match a single equal-duration step and do not advance faster than elapsed wall time.

The tests cover the private spring step helper directly, so there are no sleeps, no test-only clock hooks, and no public API changes for testability.
