### PR TITLE
memory: fix implicit comparison of unrelated types

### DIFF
--- a/include/hyprutils/memory/Atomic.hpp
+++ b/include/hyprutils/memory/Atomic.hpp
@@ -203,8 +203,8 @@ namespace Hyprutils::Memory {
             return m_ptr.get();
         }
 
-        operator bool() const {
-            return m_ptr;
+        explicit operator bool() const {
+            return static_cast<bool>(m_ptr);
         }
 
         bool operator==(const CAtomicSharedPointer& rhs) const {
@@ -366,8 +366,8 @@ namespace Hyprutils::Memory {
             return m_ptr.get();
         }
 
-        operator bool() const {
-            return m_ptr;
+        explicit operator bool() const {
+            return static_cast<bool>(m_ptr);
         }
 
         bool operator==(const CAtomicWeakPointer& rhs) const {

--- a/include/hyprutils/memory/SharedPtr.hpp
+++ b/include/hyprutils/memory/SharedPtr.hpp
@@ -106,7 +106,7 @@ namespace Hyprutils {
                 return *this;
             }
 
-            operator bool() const {
+            explicit operator bool() const {
                 return impl_ && impl_->dataNonNull();
             }
 

--- a/include/hyprutils/memory/UniquePtr.hpp
+++ b/include/hyprutils/memory/UniquePtr.hpp
@@ -67,7 +67,7 @@ namespace Hyprutils {
                 return *this;
             }
 
-            operator bool() const {
+            explicit operator bool() const {
                 return impl_;
             }
 

--- a/include/hyprutils/memory/WeakPtr.hpp
+++ b/include/hyprutils/memory/WeakPtr.hpp
@@ -154,7 +154,7 @@ namespace Hyprutils {
             }
 
             /* this returns valid() */
-            operator bool() const {
+            explicit operator bool() const {
                 return valid();
             }
 

--- a/tests/memory/Memory.cpp
+++ b/tests/memory/Memory.cpp
@@ -19,6 +19,20 @@ using namespace Hyprutils::Memory;
 #define NTHREADS   8
 #define ITERATIONS 10000
 
+namespace {
+    class Peepee {};
+    class Poopoo {};
+}
+
+template <typename A, typename B>
+concept EqualityComparable = requires(A a, B b) { a == b; };
+
+static_assert(!EqualityComparable<SP<Peepee>, SP<Poopoo>>);
+static_assert(!EqualityComparable<WP<Peepee>, WP<Poopoo>>);
+static_assert(!EqualityComparable<UP<Peepee>, UP<Poopoo>>);
+static_assert(!EqualityComparable<ASP<Peepee>, ASP<Poopoo>>);
+static_assert(!EqualityComparable<AWP<Peepee>, AWP<Poopoo>>);
+
 static void testAtomicImpl() {
     {
         // Using makeShared here could lead to invalid refcounts.
@@ -43,7 +57,7 @@ static void testAtomicImpl() {
         // Actual count is not incremented in a thread-safe manner here, so we can't check it.
         // We just want to check that the concurent refcounting doesn't cause any memory corruption.
         shared.reset();
-        EXPECT_EQ(shared, false);
+        EXPECT_FALSE(shared);
     }
 
     {
@@ -73,7 +87,7 @@ static void testAtomicImpl() {
         EXPECT_EQ(weak.valid(), false);
 
         auto shared2 = weak.lock();
-        EXPECT_EQ(shared, false);
+        EXPECT_FALSE(shared);
         EXPECT_EQ(shared2.get(), nullptr);
         EXPECT_EQ(shared.strongRef(), 0);
         EXPECT_EQ(weak.valid(), false);


### PR DESCRIPTION
Fixes `SP<A> == SP<B>` being valid. 