### PR TITLE
memory: add operators, fix a nullptr deref, and follow #115 with uniqueptr

### DIFF
--- a/include/hyprutils/memory/Atomic.hpp
+++ b/include/hyprutils/memory/Atomic.hpp
@@ -301,6 +301,9 @@ namespace Hyprutils::Memory {
         validHierarchy<const CAtomicWeakPointer<U>&> operator=(const CAtomicWeakPointer<U>& rhs) {
             reset();
 
+            if (!rhs.m_ptr.impl_)
+                return *this;
+
             auto lg = rhs.implLockGuard();
             m_ptr   = rhs.m_ptr;
             return *this;
@@ -311,6 +314,9 @@ namespace Hyprutils::Memory {
                 return *this;
 
             reset();
+
+            if (!rhs.m_ptr.impl_)
+                return *this;
 
             auto lg = rhs.implLockGuard();
             m_ptr   = rhs.m_ptr;

--- a/include/hyprutils/memory/SharedPtr.hpp
+++ b/include/hyprutils/memory/SharedPtr.hpp
@@ -44,10 +44,10 @@ namespace Hyprutils {
 
             template <typename U, typename = isConstructible<U>>
             CSharedPointer(CSharedPointer<U>&& ref) noexcept {
-                impl_       = ref.impl_;
-                m_data      = Impl_::dataPointer(sc<T*>(ref.get()));
-                ref.impl_   = nullptr;
-                ref.m_data  = nullptr;
+                impl_      = ref.impl_;
+                m_data     = Impl_::dataPointer(sc<T*>(ref.get()));
+                ref.impl_  = nullptr;
+                ref.m_data = nullptr;
             }
 
             CSharedPointer(CSharedPointer&& ref) noexcept {
@@ -121,6 +121,14 @@ namespace Hyprutils {
             // different typed pointers can be equal if the object is the same
             bool operator==(const CSharedPointer& rhs) const {
                 return impl_ == rhs.impl_;
+            }
+
+            bool operator==(std::nullptr_t) const {
+                return !(impl_ && impl_->dataNonNull());
+            }
+
+            bool operator!=(std::nullptr_t) const {
+                return impl_ && impl_->dataNonNull();
             }
 
             bool operator()(const CSharedPointer& lhs, const CSharedPointer& rhs) const {

--- a/include/hyprutils/memory/UniquePtr.hpp
+++ b/include/hyprutils/memory/UniquePtr.hpp
@@ -22,7 +22,8 @@ namespace Hyprutils {
 
             /* creates a new unique pointer managing a resource
                avoid calling. Could duplicate ownership. Prefer makeUnique */
-            explicit CUniquePointer(T* object) noexcept : impl_(new Impl_::impl_base(Impl_::dataPointer(object), [](void* p) { std::default_delete<T>{}(sc<T*>(p)); }, false)) {
+            explicit CUniquePointer(T* object) noexcept :
+                impl_(new Impl_::impl_base(Impl_::dataPointer(object), [](void* p) { std::default_delete<T>{}(sc<T*>(p)); }, false)), m_data(Impl_::dataPointer(object)) {
                 increment();
             }
 
@@ -33,11 +34,15 @@ namespace Hyprutils {
 
             template <typename U, typename = isConstructible<U>>
             CUniquePointer(CUniquePointer<U>&& ref) noexcept {
-                std::swap(impl_, ref.impl_);
+                impl_      = ref.impl_;
+                m_data     = Impl_::dataPointer(sc<T*>(ref.get()));
+                ref.impl_  = nullptr;
+                ref.m_data = nullptr;
             }
 
             CUniquePointer(CUniquePointer&& ref) noexcept {
                 std::swap(impl_, ref.impl_);
+                std::swap(m_data, ref.m_data);
             }
 
             /* creates an empty unique pointer with no implementation */
@@ -58,12 +63,17 @@ namespace Hyprutils {
 
             template <typename U>
             validHierarchy<const CUniquePointer<U>&> operator=(CUniquePointer<U>&& rhs) {
+                auto* rhsData = rhs.get();
+
                 std::swap(impl_, rhs.impl_);
+                std::swap(m_data, rhs.m_data);
+                m_data = Impl_::dataPointer(sc<T*>(rhsData));
                 return *this;
             }
 
             CUniquePointer& operator=(CUniquePointer&& rhs) noexcept {
                 std::swap(impl_, rhs.impl_);
+                std::swap(m_data, rhs.m_data);
                 return *this;
             }
 
@@ -71,8 +81,24 @@ namespace Hyprutils {
                 return impl_;
             }
 
+            bool operator==(const CUniquePointer& rhs) const {
+                return impl_ == rhs.impl_;
+            }
+
+            bool operator==(std::nullptr_t) const {
+                return !impl_;
+            }
+
+            bool operator!=(std::nullptr_t) const {
+                return impl_ != nullptr;
+            }
+
             bool operator()(const CUniquePointer& lhs, const CUniquePointer& rhs) const {
                 return rc<uintptr_t>(lhs.impl_) < rc<uintptr_t>(rhs.impl_);
+            }
+
+            bool operator<(const CUniquePointer& rhs) const {
+                return rc<uintptr_t>(impl_) < rc<uintptr_t>(rhs.impl_);
             }
 
             T* operator->() const {
@@ -85,14 +111,18 @@ namespace Hyprutils {
 
             void reset() {
                 decrement();
-                impl_ = nullptr;
+                impl_  = nullptr;
+                m_data = nullptr;
             }
 
             T* get() const {
-                return impl_ ? sc<T*>(impl_->getData()) : nullptr;
+                return impl_ && impl_->dataNonNull() ? sc<T*>(m_data) : nullptr;
             }
 
             Impl_::impl_base* impl_ = nullptr;
+
+            // Never use directly: raw data ptr, could be UAF
+            void* m_data = nullptr;
 
           private:
             /* 

--- a/tests/memory/Memory.cpp
+++ b/tests/memory/Memory.cpp
@@ -342,6 +342,41 @@ static void testVirtualHierarchy() {
         EXPECT_EQ(rightWeak->m_rightInt, 7);
         EXPECT_EQ(rightWeak.lock()->m_rightInt, 7);
     }
+
+    {
+        UP<CVirtualChild> child = makeUnique<CVirtualChild>();
+        EXPECT_TRUE(child);
+        EXPECT_EQ(child->m_virtualChildInt, 8);
+
+        UP<IVirtualRight> right = makeUnique<CVirtualChild>();
+        UP<IVirtualRoot>  root  = makeUnique<CVirtualChild>();
+
+        EXPECT_TRUE(right);
+        EXPECT_TRUE(root);
+        EXPECT_EQ(right->m_rightInt, 7);
+        EXPECT_EQ(root->m_rootInt, 5);
+
+        UP<IVirtualRoot> rootMoved = std::move(root);
+        EXPECT_TRUE(rootMoved);
+        EXPECT_FALSE(root);
+        EXPECT_EQ(rootMoved->m_rootInt, 5);
+
+        UP<IVirtualRight> rightAssigned;
+        rightAssigned = makeUnique<CVirtualChild>();
+        EXPECT_TRUE(rightAssigned);
+        EXPECT_EQ(rightAssigned->m_rightInt, 7);
+
+        WP<IVirtualRoot>  rootWeak  = right;
+        WP<IVirtualRight> rightWeak = right;
+
+        EXPECT_TRUE(rootWeak);
+        EXPECT_TRUE(rightWeak);
+        EXPECT_EQ(rootWeak->m_rootInt, 5);
+        EXPECT_EQ(rightWeak->m_rightInt, 7);
+
+        // unique pointers cannot be locked
+        EXPECT_FALSE(rightWeak.lock());
+    }
 }
 
 static void testConstPointers() {


### PR DESCRIPTION
an atomic, if assigning from a empty weakpointer rhs.implLockGuard() will nullptr
deref

```
rhs.implLockGuard();

std::lock_guard<std::recursive_mutex> implLockGuard() const {
	return impl()->lockGuard();
}

Atomic_::impl* impl() const {
	return sc<Atomic_::impl*>(m_ptr.impl_);
}
```
so avoid that.

add nullptr_t operators to sharedptr, weakptr has them, and i think it works without these because of the
implicit CSharedPointer(std::nullptr_t) constructor and later just hitting the bool operator==(const CSharedPointer& rhs) 
which will compare impl_ == nullptr.
but lets just add them properly.

in uniqueptr add comparision operators like sharedptr/weakptr.

PR https://github.com/hyprwm/hyprutils/pull/115 added m_data for fixing multiple/virtual-inheritance in SP/WP
but not in UP, as that PR did add it to uniqueptr aswell. since it can
also have multiple virtual inheritance. also add test for it.