### PR TITLE
weakptr: check for expired in casting

### DIFF
--- a/include/hyprutils/memory/WeakPtr.hpp
+++ b/include/hyprutils/memory/WeakPtr.hpp
@@ -264,7 +264,11 @@ namespace Hyprutils {
 
         template <typename T, typename U>
         CWeakPointer<T> dynamicPointerCast(const CWeakPointer<U>& ref) {
-            if (!ref)
+            // expired() (unlike !ref / !valid()) is also true while the referent
+            // is mid-destruction: its data pointer is still non-null but the
+            // derived subobjects are already gone, so its vptr no longer denotes
+            // a U. dynamic_cast'ing that is undefined behaviour, so bail here.
+            if (!ref || ref.expired())
                 return nullptr;
             T* newPtr = dynamic_cast<T*>(ref.get());
             if (!newPtr)


### PR DESCRIPTION
dynamicPointerCast has to check for expired aswell.

```
/usr/include/hyprutils/memory/WeakPtr.hpp:262:25: runtime error: cast to virtual base of address 0x5649b21d8d60 which does not point to an object of type 'CWindow'
0x5649b21d8d60: note: object is of type 'Desktop::View::IAlphaModifiable'
 00 00 00 00  30 af 12 a8 49 56 00 00  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'Desktop::View::IAlphaModifiable'
    #0 0x5649a4e971df in Hyprutils::Memory::CWeakPointer<Desktop::View::IView> Hyprutils::Memory::dynamicPointerCast<Desktop::View::IView, Desktop::View::CWindow>(Hyprutils::Memory::CWeakPointer<Desktop::View::CWindow> const&) /usr/include/hyprutils/memory/WeakPtr.hpp:262
    #1 0x5649a4e84be9 in operator()<Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow> > /home/tom/Dev/Hyprland/src/desktop/state/WindowState.cpp:24
    #2 0x5649a4e86ac1 in __find_if<__gnu_cxx::__normal_iterator<Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow>*, std::vector<Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow> > >, Desktop::CWindowState::CWindowState()::<lambda(const Event::SViewDestroyEvent&)>::<lambda(auto:71&)> > /usr/include/c++/16/bits/stl_algobase.h:2100
    #3 0x5649a4e84e31 in __remove_if<__gnu_cxx::__normal_iterator<Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow>*, std::vector<Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow> > >, Desktop::CWindowState::CWindowState()::<lambda(const Event::SViewDestroyEvent&)>::<lambda(auto:71&)> > /usr/include/c++/16/bits/stl_algobase.h:2123
    #4 0x5649a4e83264 in __erase_if<std::vector<Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow> >, std::vector<Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow> >, Desktop::CWindowState::CWindowState()::<lambda(const Event::SViewDestroyEvent&)>::<lambda(auto:71&)> > /usr/include/c++/16/bits/erase_if.h:57
    #5 0x5649a4e81335 in erase_if<Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow>, std::allocator<Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow> >, Desktop::CWindowState::CWindowState()::<lambda(const Event::SViewDestroyEvent&)>::<lambda(auto:71&)> > /usr/include/c++/16/vector:118
    #6 0x5649a4e7ddd8 in operator() /home/tom/Dev/Hyprland/src/desktop/state/WindowState.cpp:24
    #7 0x5649a4e86cc1 in __invoke_impl<void, Desktop::CWindowState::CWindowState()::<lambda(const Event::SViewDestroyEvent&)>&, const Event::SViewDestroyEvent&> /usr/include/c++/16/bits/invoke.h:63
    #8 0x5649a4e858b6 in __invoke_r<void, Desktop::CWindowState::CWindowState()::<lambda(const Event::SViewDestroyEvent&)>&, const Event::SViewDestroyEvent&> /usr/include/c++/16/bits/invoke.h:113
    #9 0x5649a4e83a94 in _M_invoke /usr/include/c++/16/bits/std_function.h:295
    #10 0x5649a4e574ef in std::function<void (Event::SViewDestroyEvent const&)>::operator()(Event::SViewDestroyEvent const&) const /usr/include/c++/16/bits/std_function.h:581
    #11 0x5649a4e54853 in Hyprutils::Signal::CSignalT<Event::SViewDestroyEvent>::mkHandler(std::function<void (Event::SViewDestroyEvent const&)>)::{lambda(void*)#1}::operator()(void*) const /usr/include/hyprutils/signal/Signal.hpp:100
    #12 0x5649a4e5bc3f in void std::__invoke_impl<void, Hyprutils::Signal::CSignalT<Event::SViewDestroyEvent>::mkHandler(std::function<void (Event::SViewDestroyEvent const&)>)::{lambda(void*)#1}&, void*>(std::__invoke_other, Hyprutils::Signal::CSignalT<Event::SViewDestroyEvent>::mkHandler(std::function<void (Event::SViewDestroyEvent const&)>)::{lambda(void*)#1}&, void*&&) /usr/include/c++/16/bits/invoke.h:63
    #13 0x5649a4e5a8d7 in std::enable_if<is_invocable_r_v<void, Hyprutils::Signal::CSignalT<Event::SViewDestroyEvent>::mkHandler(std::function<void (Event::SViewDestroyEvent const&)>)::{lambda(void*)#1}&, void*>, void>::type std::__invoke_r<void, Hyprutils::Signal::CSignalT<Event::SViewDestroyEvent>::mkHandler(std::function<void (Event::SViewDestroyEvent const&)>)::{lambda(void*)#1}&, void*>(Hyprutils::Signal::CSignalT<Event::SViewDestroyEvent>::mkHandler(std::function<void (Event::SViewDestroyEvent const&)>)::{lambda(void*)#1}&, void*&&) /usr/include/c++/16/bits/invoke.h:113
    #14 0x5649a4e59535 in std::_Function_handler<void (void*), Hyprutils::Signal::CSignalT<Event::SViewDestroyEvent>::mkHandler(std::function<void (Event::SViewDestroyEvent const&)>)::{lambda(void*)#1}>::_M_invoke(std::_Any_data const&, void*&&) /usr/include/c++/16/bits/std_function.h:295
    #15 0x7f813797c548 in Hyprutils::Signal::CSignalListener::emitInternal(void*) (/usr/lib/libhyprutils.so.12+0x44548) (BuildId: 4f8f42c1150634625ed09e0b497c858ee25affdb)
    #16 0x7f813797ca73 in Hyprutils::Signal::CSignalBase::emitInternal(void*) (/usr/lib/libhyprutils.so.12+0x44a73) (BuildId: 4f8f42c1150634625ed09e0b497c858ee25affdb)
    #17 0x5649a4fa81f0 in Hyprutils::Signal::CSignalT<Event::SViewDestroyEvent>::emit(Event::SViewDestroyEvent const&) /usr/include/hyprutils/signal/Signal.hpp:43
    #18 0x5649a4fa48c4 in Desktop::View::IView::~IView() /home/tom/Dev/Hyprland/src/desktop/view/View.cpp:20
    #19 0x5649a4ffbea9 in Desktop::View::CWindow::~CWindow() /home/tom/Dev/Hyprland/src/desktop/view/Window.cpp:224
    #20 0x5649a4ffbef2 in Desktop::View::CWindow::~CWindow() /home/tom/Dev/Hyprland/src/desktop/view/Window.cpp:224
    #21 0x5649a510db53 in std::default_delete<Desktop::View::CWindow>::operator()(Desktop::View::CWindow*) const /usr/include/c++/16/bits/unique_ptr.h:92
    #22 0x5649a50f956e in Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow>::_delete(void*) /usr/include/hyprutils/memory/SharedPtr.hpp:172
    #23 0x5649a456845e in Hyprutils::Memory::Impl_::impl_base::_destroy() /usr/include/hyprutils/memory/ImplBase.hpp:92
    #24 0x5649a45680b9 in Hyprutils::Memory::Impl_::impl_base::destroy() /usr/include/hyprutils/memory/ImplBase.hpp:47
    #25 0x5649a46d6845 in Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow>::destroyImpl(Hyprutils::Memory::Impl_::impl_base*) /usr/include/hyprutils/memory/SharedPtr.hpp:202
    #26 0x5649a46d284e in Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow>::decrement(Hyprutils::Memory::Impl_::impl_base*) /usr/include/hyprutils/memory/SharedPtr.hpp:188
    #27 0x5649a46cb9ae in Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow>::~CSharedPointer() /usr/include/hyprutils/memory/SharedPtr.hpp:72
    #28 0x5649a4e98256 in void std::destroy_at<Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow> >(Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow>*) /usr/include/c++/16/bits/stl_construct.h:88
    #29 0x5649a4e96ee8 in void std::_Destroy<Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow> >(Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow>*) /usr/include/c++/16/bits/stl_construct.h:164
    #30 0x5649a4e924cf in void std::_Destroy<Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow>*>(Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow>*, Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow>*) /usr/include/c++/16/bits/stl_construct.h:226
    #31 0x5649a4e91f81 in void std::_Destroy<Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow>*, Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow> >(Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow>*, Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow>*, std::allocator<Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow> >&) /usr/include/c++/16/bits/alloc_traits.h:1085
    #32 0x5649a4e91f81 in std::vector<Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow>, std::allocator<Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow> > >::_M_erase_at_end(Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow>*) /usr/include/c++/16/bits/stl_vector.h:2233
    #33 0x5649a4e8cd8e in std::vector<Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow>, std::allocator<Hyprutils::Memory::CSharedPointer<Desktop::View::CWindow> > >::clear() /usr/include/c++/16/bits/stl_vector.h:1854
    #34 0x5649a4e80df0 in Desktop::CWindowState::clear() /home/tom/Dev/Hyprland/src/desktop/state/WindowState.cpp:122
    #35 0x5649a45f6d44 in CCompositor::cleanup() /home/tom/Dev/Hyprland/src/Compositor.cpp:585
    #36 0x5649a455fd11 in main /home/tom/Dev/Hyprland/src/main.cpp:300
    #37 0x7f8134627c8d  (/usr/lib/libc.so.6+0x27c8d) (BuildId: e40d0fb39fa49848e0042984207f7c80fdbc8c7e)
    #38 0x7f8134627dca in __libc_start_main (/usr/lib/libc.so.6+0x27dca) (BuildId: e40d0fb39fa49848e0042984207f7c80fdbc8c7e)
    #39 0x5649a455b354 in _start (/home/tom/Dev/Hyprland/build/Desktop_Debug/Hyprland+0x8c4c354) (BuildId: 88983405ce5a25575a5140e5185c7e297d33a50f)
```